### PR TITLE
Paginate

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -88,7 +88,7 @@ class SocialEvent(OrgEvent):
     location = models.CharField(max_length=100, default="")
     list = models.ManyToManyField(Attendee, blank=True)
     party_mode = models.BooleanField(default=False)
-
+    
     objects = SocialEventManager()
 
     def __str__(self):

--- a/core/templates/core/social.html
+++ b/core/templates/core/social.html
@@ -6,7 +6,7 @@
     <div class="container">
         <h2>Events</h2>
         <div class="list-group">
-            {% for event in events %}
+            {% for event in page_obj %}
             <a href="social_event{{ event.id }}" class="list-group-item">{{ event.name }} -- {{ event.date }}, {{ event.time }} <span class="badge badge-info">{{ event.list.count }}</span></a>
             {% endfor %}
         </div>
@@ -63,5 +63,64 @@
     <br>
     <br>
     {% endif %}
+</div>
+
+<!-- <div class="pagination">
+    <span class="step-links">
+        {% if page_obj.has_previous %}
+            <a href="?page=1">&laquo; first</a>
+            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+        {% endif %}
+
+        <span class="current">
+            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+        </span>
+
+        {% if page_obj.has_next %}
+            <a href="?page={{ page_obj.next_page_number }}">next</a>
+            <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
+        {% endif %}
+    </span>
+</div> -->
+
+
+<div class="container">
+    <div class='row title-row my-1'>
+        <div class='col-12 py-1'>
+            <nav aria-label="Page navigation">
+                <ul class="pagination justify-content-center">
+        {% if page_obj.has_previous %}
+
+        <li class ="page-item"><a class ="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
+        {% else %}
+            <li class="page-item disabled">
+                <span class="page-link">Previous</span>
+            </li>
+        {% endif %}
+
+        {% for i in page_obj.paginator.page_range %}
+                            {% if page_obj.number == i %}
+                                <li class="page-item active">
+                                <a class="page-link" href="?page={{ i }}">{{ i }}<span class="sr-only">(current)</span></a>
+                                </li>
+                        {% else %}
+                            <li class="page-item"><a class="page-link" href="?page={{ i }}">{{ i }}</a></li>
+
+                        {% endif %}
+                        {% endfor %}
+
+        {% if page_obj.has_next %}
+
+        <li class ="page-item"><a class ="page-link" href="?page={{ page_obj.next_page_number }}">Next</a></li>
+
+        {% else %}
+        <li class="page-item disabled">
+            <span class="page-link">Next</span>
+        </li>
+        {% endif %}
+    </ul>
+</nav>
+</div>
+</div>
 </div>
 {% endblock %}

--- a/core/templates/core/social.html
+++ b/core/templates/core/social.html
@@ -61,10 +61,10 @@
         </div>
     </div>
     <br>
-    <br>
     {% endif %}
+    <br>
 </div>
-
+{% if eventscount > 10 %}
 <div class="container">
     <div class='row title-row my-1'>
         <div class='col-12 py-1'>
@@ -104,4 +104,6 @@
 </div>
 </div>
 </div>
+
+{% endif %}
 {% endblock %}

--- a/core/templates/core/social.html
+++ b/core/templates/core/social.html
@@ -65,25 +65,6 @@
     {% endif %}
 </div>
 
-<!-- <div class="pagination">
-    <span class="step-links">
-        {% if page_obj.has_previous %}
-            <a href="?page=1">&laquo; first</a>
-            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
-        {% endif %}
-
-        <span class="current">
-            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
-        </span>
-
-        {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}">next</a>
-            <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
-        {% endif %}
-    </span>
-</div> -->
-
-
 <div class="container">
     <div class='row title-row my-1'>
         <div class='col-12 py-1'>

--- a/core/views.py
+++ b/core/views.py
@@ -32,7 +32,9 @@ from django.db import IntegrityError, transaction
 from django.contrib import messages
 from django.http import JsonResponse
 from django.views.generic import ListView
-
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.shortcuts import render
+import datetime
 # Create your views here.
 
 
@@ -231,11 +233,26 @@ def removeCal(request):
 
 @login_required
 def social(request):
+     
     template = loader.get_template('core/social.html')
-    events = SocialEvent.objects.all().order_by('-date')
+
+    now = datetime.datetime.now()
+    upcoming = SocialEvent.objects.filter(date__gte=now).order_by('date', 'time')   #today, then tomorrow, tomorrow + 1
+    past = SocialEvent.objects.filter(date__lt=now).order_by('-date', '-time')      #yesterday, day before yesterday
+
+    events = chain(upcoming, past)
+    events = list(events)                                                           #converts to list, necessary for paginator
+    # events = SocialEvent.objects.all().order_by('-date', 'time')                  lets keep this just in case something goes wrong with the query chain
+
+    #for pagination
+    paginator = Paginator(events, 10)                                               #this number changes items per page
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
     context = {
         'settings': getSettings(),
         'social_page': "active",
+        'page_obj': page_obj,
         'events': events,
     }
     return HttpResponse(template.render(context, request))

--- a/core/views.py
+++ b/core/views.py
@@ -248,12 +248,14 @@ def social(request):
     paginator = Paginator(events, 10)                                               #this number changes items per page
     page_number = request.GET.get('page')
     page_obj = paginator.get_page(page_number)
+    eventscount = len(events)
 
     context = {
         'settings': getSettings(),
         'social_page': "active",
         'page_obj': page_obj,
         'events': events,
+        'eventscount' : eventscount
     }
     return HttpResponse(template.render(context, request))
 


### PR DESCRIPTION
Added pagination for social events. Also updated order of the social events.

Order example:
Today
Today 
Tomorrow
Tomorrow +1
Yesterday
Day before yesterday

Events that are earlier are on top only for today and future events. For events in the past, events that are earlier are lower.

Example:
Today (12:00pm)
Today (9:00pm)
Tomorrow (12:00pm)
Tomorrow (10:00pm)
Yesterday (9:00 pm)
Yesterday (9:00am)