### PR TITLE
Multitenant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ htmlcov
 # ignore Pycharm files
 .idea
 
+# ignore MacOSX files
+.DS_Store
+
 # ignore Django binaries
 __pycache__/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database greeklinkdb;' -U postgres
-  - psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"
+  - psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser; ALTER USER greeklinkuser CREATEDB;"
 # command to install dependencies
 install:
   - pip install -r requirements.txt
@@ -16,6 +16,9 @@ env:
 # command to run tests
 script:
   - python manage.py makemigrations core
-  - python manage.py migrate
+  - python manage.py makemigrations organizations
+  - python manage.py makemigrations rush
+  - python manage.py makemigrations cal
+  - python manage.py migrate_schemas
   - python manage.py collectstatic
   - python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 python:
   - "3.6"
+# postgres database
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database greeklinkdb;' -U postgres
+  - psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/cal/forms.py
+++ b/cal/forms.py
@@ -13,6 +13,8 @@ class ChapterEventForm(ModelForm):
         widget=forms.TimeInput(attrs={'type': 'time', 'class': 'form-control rounded', 'placeholder': "HH:mm:ss in 24 hour time"}))
     location = forms.CharField(max_length=50, label='Location',
         widget=forms.TextInput(attrs={'class': 'form-control rounded'}))
+    public = forms.BooleanField(label='Make event public?', required=False,
+        widget=forms.CheckboxInput())
     recurring = forms.ChoiceField(choices=RECURRENCE_CHOICES, label="Recurring",
         widget=forms.Select(attrs={'id': 'recurring_selection', 'class': 'form-control rounded'}))
     end_date = forms.DateField(label='End Date', required=False, initial=datetime.date.today,

--- a/cal/models.py
+++ b/cal/models.py
@@ -14,24 +14,24 @@ RECURRENCE_CHOICES = [
 ]
 
 class ChapterEventManager(models.Manager):
-    def create_chapter_event(self, name, date, time, location, recurring='None', end_date=None):
-        event = self.create(name=name, date=date, time=time, location=location, recurring=recurring, end_date=end_date)
+    def create_chapter_event(self, name, date, time, is_public, location, recurring='None', end_date=None):
+        event = self.create(name=name, date=date, time=time, is_public=is_public, location=location, recurring=recurring, end_date=end_date)
         if event.recurring == 'Monthly' and not event.is_recurrence:
             start_date = event.date + relativedelta(months=+1)
             while start_date <= event.end_date:
-                ChapterEvent.objects.create(name=event.name, date=start_date, time=event.time, location=event.location, 
+                ChapterEvent.objects.create(name=event.name, date=start_date, time=event.time, is_public=is_public, location=event.location, 
                                             recurring='Monthly', is_recurrence=True, end_date=event.end_date, base_event=event)
                 start_date += relativedelta(months=+1)
         if event.recurring == 'Weekly' and not event.is_recurrence:
             start_date = event.date + relativedelta(weeks=+1)
             while start_date <= event.end_date:
-                ChapterEvent.objects.create(name=event.name, date=start_date, time=event.time, location=event.location, 
+                ChapterEvent.objects.create(name=event.name, date=start_date, time=event.time, is_public=is_public, location=event.location, 
                                             recurring='Weekly', is_recurrence=True, end_date=event.end_date, base_event=event)
                 start_date += relativedelta(weeks=+1)
         if event.recurring == 'Daily' and not event.is_recurrence:
             start_date = event.date + relativedelta(days=+1)
             while start_date <= event.end_date:
-                ChapterEvent.objects.create(name=event.name, date=start_date, time=event.time, location=event.location, 
+                ChapterEvent.objects.create(name=event.name, date=start_date, time=event.time, is_public=is_public, location=event.location, 
                                             recurring='Daily', is_recurrence=True, end_date=event.end_date, base_event=event)
                 start_date += relativedelta(days=+1)
         return event
@@ -48,6 +48,7 @@ class ChapterEvent(OrgEvent):
     end_date = models.DateField(null=True, blank=True)
     is_recurrence = models.BooleanField(default=False)
     base_event = models.ForeignKey('self', null=True, blank=True, on_delete=models.SET_NULL, related_name='children')
+    is_public = models.BooleanField(default=False)
 
     def delete(self, *args, **kwargs):
         """ overrides delete method to fit recurrence """

--- a/cal/templates/cal/date.html
+++ b/cal/templates/cal/date.html
@@ -9,7 +9,7 @@
     <a href="/cal/date/{{next_date.year}}/{{next_date.month}}/{{next_date.day}}"><button class="btn btn-primary btn-sm"><i class="fa fa-chevron-right" aria-hidden="true"></i></button></a><br>
     <a href="/cal"><button class="btn btn-danger btn-sm" style="margin-top: 15px">Back to calendar</button></a>
     <hr>
-    {% if all_events %}
+    {% if all_events or community_events %}
         <ul class="list-group">  
             {% for event in all_events %}
             <li class="list-group-item">
@@ -18,6 +18,17 @@
             </li>
             {% endfor %}
         </ul>
+        {% if community_events %}
+        <h3>Community Events</h3>
+        <ul class="list-group">
+            {% for event in community_events %}
+            <!-- community_events is a list of tuples, the first element in each tuple is the event, the second is the organization it belongs to -->
+            <li class="list-group-item">
+                {{ event.1 }}'s {{ event.0.name }} -- {{ event.0.time }}
+                <br>
+            </li>
+            {% endfor %}
+        {% endif %}
     {% else %}
         <b><i>No events today</i></b>
     {% endif %}

--- a/cal/templates/cal/index.html
+++ b/cal/templates/cal/index.html
@@ -62,6 +62,15 @@
                         </div>
                     </div>
                     <div class="form-group row">
+                        <div class="col-sm-2">
+                            {{ event_form.public }}
+                        </div>
+                        <div class="col-sm-10">
+                            {{ event_form.public.label }}<br>
+                            <small>Making an event public will make it visible to other organizations in your community</small>
+                        </div>
+                    </div>
+                    <div class="form-group row">
                         <div class="col-sm-2 col-form-label">
                             {{ event_form.recurring.label }}
                         </div>
@@ -107,10 +116,12 @@
                 <p><span class="alert alert-success calendar-key"> </span> &nbsp;&nbsp;Rush Event</p>
                 <p><span class="alert alert-primary calendar-key"> </span> &nbsp;&nbsp;Social Event</p>
                 <p><span class="alert alert-secondary calendar-key"> </span> &nbsp;&nbsp;Chapter Event</p>
+                <p><span class="alert alert-info calendar-key"> </span> &nbsp;&nbsp;Public Event</p>
                 {% else %}
                 <p>Days with a grey highlight have an event scheduled.  Click on the date to view them!</p>
                 {% endif %}
                 <p>Rush and Social Events are added to this calendar automatically as they are created by admins in the Rush and Social tabs.  Click on any of these events to be redirected to the corresponding event.  Chapter events are events not associated with rush or social.</p>
+                <p>Public events are events that other organizations have added to their calendar and elected to make public to the community.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
@@ -181,6 +192,19 @@
                         {% else %}
                         {{ event.location }}
                         {% endif %}
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-sm-2" style="text-align: center">
+                        {% if perms.cal.change_chapterevent %}
+                        <input type="checkbox" name="public" class="form-check-input" {% if event.is_public %}checked{% endif %}>
+                        {% else %}
+                        <input type="checkbox" name="public" class="form-check-input" {% if event.is_public %}checked{% endif %} disabled>
+                        {% endif %}
+                    </div>
+                    <div class="col-sm-10">
+                        Public?<br>
+                        <small>Public events are visible to other organizations in your community</small>
                     </div>
                 </div>
                 {% if event.recurring != 'None' and not perms.cal.change_chapterevent %}

--- a/cal/tests.py
+++ b/cal/tests.py
@@ -7,10 +7,13 @@ from rush.models import RushEvent
 from .models import ChapterEvent
 from dateutil.relativedelta import relativedelta
 from .forms import ChapterEventForm
+from tenant_schemas.test.cases import TenantTestCase
+from tenant_schemas.test.client import TenantClient
 
-class CalendarTestCase(TestCase):
+class CalendarTestCase(TenantTestCase):
     """ tests basic appearance and functionality of calendar """
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.user = User.objects.create(username='test', is_superuser=True, is_staff=True)
         self.client.force_login(self.user)
         self.rush_event = RushEvent.objects.create(name="rush_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
@@ -126,9 +129,10 @@ class CalendarTestCase(TestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class DeleteChapterEventsTestCase(TestCase):
+class DeleteChapterEventsTestCase(TenantTestCase):
     """ tests deleting Chapter Events, both singularly and recursively """
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.user = User.objects.create(username="test", is_superuser=True, is_staff=True)
         self.client.force_login(self.user)
         self.singular = ChapterEvent.objects.create_chapter_event(name="singular event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
@@ -189,9 +193,10 @@ class DeleteChapterEventsTestCase(TestCase):
         except ChapterEvent.DoesNotExist:
             pass
 
-class EditChapterEventTestCase(TestCase):
+class EditChapterEventTestCase(TenantTestCase):
     """ tests editing chapter events """
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.user = User.objects.create(username="test_user", is_superuser=True, is_staff=True)
         self.client.force_login(self.user)
         self.singular = ChapterEvent.objects.create_chapter_event(name="singular event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")

--- a/cal/tests.py
+++ b/cal/tests.py
@@ -18,7 +18,7 @@ class CalendarTestCase(TenantTestCase):
         self.client.force_login(self.user)
         self.rush_event = RushEvent.objects.create(name="rush_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
         self.social_event = SocialEvent.objects.create(name="social_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
-        self.chapter_event = ChapterEvent.objects.create_chapter_event(name="chapter_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
+        self.chapter_event = ChapterEvent.objects.create_chapter_event(name="chapter_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), is_public=False, location="test")
     
     def test_calendar_template(self):
         """ tests that the current month appears by default """
@@ -47,7 +47,7 @@ class CalendarTestCase(TenantTestCase):
 
     def test_chapter_event_recurrence(self):
         """ tests that chapter events are recurring properly """
-        event = ChapterEvent.objects.create_chapter_event(name="recurrence_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test", recurring='Daily', end_date=datetime.strptime("2020-07-21", "%Y-%m-%d").date())
+        event = ChapterEvent.objects.create_chapter_event(name="recurrence_test", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), is_public=False, location="test", recurring='Daily', end_date=datetime.strptime("2020-07-21", "%Y-%m-%d").date())
         path = "%s?month=7&year=2020" % reverse('cal:index')
         response = self.client.post(path)
         self.assertContains(response, 'recurrence_test', count=6)   # 2 events on calendar, 2 modal titles, 2 in modal details
@@ -135,8 +135,8 @@ class DeleteChapterEventsTestCase(TenantTestCase):
         self.client = TenantClient(self.tenant)
         self.user = User.objects.create(username="test", is_superuser=True, is_staff=True)
         self.client.force_login(self.user)
-        self.singular = ChapterEvent.objects.create_chapter_event(name="singular event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
-        self.recurring = ChapterEvent.objects.create_chapter_event(name="recurring event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test",
+        self.singular = ChapterEvent.objects.create_chapter_event(name="singular event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), is_public=False, location="test")
+        self.recurring = ChapterEvent.objects.create_chapter_event(name="recurring event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), is_public=False, location="test",
                                                      recurring='Daily', end_date=datetime.strptime("2020-07-25", "%Y-%m-%d").date())
 
 
@@ -199,8 +199,8 @@ class EditChapterEventTestCase(TenantTestCase):
         self.client = TenantClient(self.tenant)
         self.user = User.objects.create(username="test_user", is_superuser=True, is_staff=True)
         self.client.force_login(self.user)
-        self.singular = ChapterEvent.objects.create_chapter_event(name="singular event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test")
-        self.recurring = ChapterEvent.objects.create_chapter_event(name="recurring event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), location="test",
+        self.singular = ChapterEvent.objects.create_chapter_event(name="singular event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), is_public=False, location="test")
+        self.recurring = ChapterEvent.objects.create_chapter_event(name="recurring event", date=datetime.strptime("2020-07-20", "%Y-%m-%d").date(), time=datetime.now(), is_public=False, location="test",
                                                      recurring='Daily', end_date=datetime.strptime("2020-07-26", "%Y-%m-%d").date())
     
     def test_edit_singular(self):

--- a/cal/views.py
+++ b/cal/views.py
@@ -12,6 +12,8 @@ from dateutil.relativedelta import relativedelta
 from itertools import chain
 from django.contrib.auth.decorators import login_required, permission_required
 from .forms import ChapterEventForm
+from organizations.models import Client
+from tenant_schemas.utils import tenant_context
 
 class Calendar(HTMLCalendar):
     def __init__(self, request, year=None, month=None):
@@ -25,6 +27,15 @@ class Calendar(HTMLCalendar):
             social_events_per_day = social_events.filter(date__day=day)
             rush_events_per_day = rush_events.filter(date__day=day)
             chapter_events_per_day = chapter_events.filter(date__day=day)
+            public_social_events_per_day = []
+            public_chapter_events_per_day = []
+            org_community = self.request.tenant.community
+            for tenant in Client.objects.filter(community=org_community).exclude(name=self.request.tenant.name).all():
+                with tenant_context(tenant):
+                    for event in SocialEvent.objects.filter(is_public=True, date__month=self.month, date__year=self.year, date__day=day):
+                        public_social_events_per_day.append((event, tenant.name))
+                    for event in ChapterEvent.objects.filter(is_public=True, date__month=self.month, date__year=self.year, date__day=day):
+                        public_chapter_events_per_day.append((event, tenant.name))
             d = ''
             for event in social_events_per_day:
                 time = event.time.strftime("%I:%M %p").lstrip("0")
@@ -35,6 +46,12 @@ class Calendar(HTMLCalendar):
             for event in chapter_events_per_day:
                 time = event.time.strftime("%I:%M %p").lstrip("0")
                 d += f'<div class="alert alert-secondary alert-calendar"><a href="" data-toggle="modal" data-target="#detailModal_{ event.pk }">{ time } - { event.name }</a></div>'
+            for event in public_social_events_per_day:
+                time = event[0].time.strftime("%I:%M %p").lstrip("0")
+                d += f'<div class="alert alert-info alert-calendar">{ time } - { event[1] }\'s { event[0].name }</div>'
+            for event in public_chapter_events_per_day:
+                time = event[0].time.strftime("%I:%M %p").lstrip("0")
+                d += f'<div class="alert alert-info alert-calendar"> { time } - { event[1] }\'s { event[0].name }</div>'
             if day != 0 and d != '':
                 return f"<td class='day-cell table-active'><span class='date'><a href='/cal/date/{self.year}/{self.month}/{day}'>{day}</a></span> <div class='scrollable'>{d}</div></td>"
             elif day != 0:
@@ -101,9 +118,22 @@ def date(request, year, month, day):
     social_events = SocialEvent.objects.filter(date=this_date)
     rush_events = RushEvent.objects.filter(date=this_date)
     chapter_events = ChapterEvent.objects.filter(date=this_date)
+    public_social_events = []
+    public_chapter_events = []
+    org_community = request.tenant.community
+    for tenant in Client.objects.filter(community=org_community).exclude(name=request.tenant.name).all():
+                with tenant_context(tenant):
+                    for event in SocialEvent.objects.filter(is_public=True, date=this_date):
+                        public_social_events.append((event, tenant.name))
+                    for event in ChapterEvent.objects.filter(is_public=True, date=this_date):
+                        public_chapter_events.append((event, tenant.name))
     all_events = sorted(
         chain(social_events, rush_events, chapter_events),
         key=lambda instance: instance.time
+    )
+    community_events = sorted(
+        chain(public_social_events, public_chapter_events),
+        key=lambda instance: instance[0].time
     )
     context = {
         'settings': getSettings(),
@@ -114,6 +144,7 @@ def date(request, year, month, day):
         'rush_events': rush_events,
         'chapter_events': chapter_events,
         'all_events': all_events,
+        'community_events': community_events,
         'next_date': this_date + timedelta(days=1),
         'prev_date': this_date - timedelta(days=1)
     }
@@ -128,10 +159,11 @@ def create_chapter_event(request):
             date = form.cleaned_data.get('date')
             time = form.cleaned_data.get('time')
             location = form.cleaned_data.get('location')
+            is_public = form.cleaned_data.get('public')
             recurring = form.cleaned_data.get('recurring')
             end_date = form.cleaned_data.get('end_date')
 
-            ChapterEvent.objects.create_chapter_event(name, date, time, location, recurring, end_date)
+            ChapterEvent.objects.create_chapter_event(name, date, time, is_public, location, recurring, end_date)
 
             return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
         else:
@@ -164,9 +196,13 @@ def edit_chapter_event(request, event_id):
             date = datetime.strptime(request.POST.get('date'), "%Y-%m-%d").date()
             time = request.POST.get('time')
             location = request.POST.get('location')
+            if request.POST.get('public') == 'on':
+                is_public = True
+            else:
+                is_public = False
             recurring = request.POST.get('recurring')
             end_date = datetime.strptime(request.POST.get('end_date'), "%Y-%m-%d").date()
-            new_event = ChapterEvent.objects.create(name=name, date=date, time=time, location=location, recurring=recurring, end_date=end_date)
+            new_event = ChapterEvent.objects.create(name=name, date=date, time=time, is_public=is_public, location=location, recurring=recurring, end_date=end_date)
             return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
         else:
             ChapterEvent.objects.get(pk=event_id).delete_all()
@@ -174,9 +210,13 @@ def edit_chapter_event(request, event_id):
             date = datetime.strptime(request.POST.get('date'), "%Y-%m-%d").date()
             time = request.POST.get('time')
             location = request.POST.get('location')
+            if request.POST.get('public') == 'on':
+                is_public = True
+            else:
+                is_public = False
             recurring = request.POST.get('recurring')
             end_date = datetime.strptime(request.POST.get('end_date'), "%Y-%m-%d").date()
-            ChapterEvent.objects.create_chapter_event(name=name, date=date, time=time, location=location, recurring=recurring, end_date=end_date)
+            ChapterEvent.objects.create_chapter_event(name=name, date=date, time=time, is_public=is_public, location=location, recurring=recurring, end_date=end_date)
             return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
     else:
         raise Http404

--- a/core/models.py
+++ b/core/models.py
@@ -131,6 +131,7 @@ class SocialEvent(OrgEvent):
     """
     list_limit = models.IntegerField(default=-1)
     party_mode = models.BooleanField(default=False)
+    is_public = models.BooleanField(default=False)
 
     objects = SocialEventManager()
 

--- a/core/models.py
+++ b/core/models.py
@@ -4,7 +4,6 @@ from django.db import models
 from django.db.models import Q
 from django.urls import reverse
 
-
 from django.contrib.auth.models import User, Group, Permission
 
 # Stores site settings in a single model

--- a/core/templates/core/communities.html
+++ b/core/templates/core/communities.html
@@ -30,21 +30,14 @@
                         <h5 class="card-title">Login</h5>
                             <form method="post">
                                 {% csrf_token %}
-                                {% if form.errors %}
-                                <div class="alert alert-danger" role="alert">
-                                    Invalid username or password
-                                </div>
-                                {% endif %}
                                 <div class="form-group">
-                                    {{ form.username }}
-                                </div>
+                                    <div style='text-align: left'>
+                                        <b>{{ form.organization.label }}</b>
+                                    </div><br>
+                                    {{ form.organization }}
+                                </div>                           
                                 <div class="form-group">
-                                    {{ form.password }}
-                                    <small style="text-align: left"><a href="/forgot_credentials">I forgot my username or password</a></small>
-                                </div>                               
-                                <div class="form-group">
-                                <button type="submit" class="btn btn-primary">Login</button> {% if request.user_agent.is_mobile %}<br><br>{% endif %}
-                                <a href="/signup"><button class='btn btn-secondary' type="button">I don't have an account</button></a>
+                                <button type="submit" class="btn btn-primary">Submit</button> {% if request.user_agent.is_mobile %}<br><br>{% endif %}
                             </form>
                     </div>
                 </div>

--- a/core/templates/core/social.html
+++ b/core/templates/core/social.html
@@ -74,8 +74,13 @@
                                                 </div>
                                             </div>
                                             <div class="form-group form-check">
+                                                <input type="checkbox" class="form-check-input" id="public_checkbox_{{ event.id }}" name="public" {% if event.is_public %} checked {% endif %}>
+                                                <label class="form-check-label" for="public">Make event public?</label>
+                                                <small>Making an event public will allow other organizations in your community to see the event on their calendar.</small>
+                                            </div>
+                                            <div class="form-group form-check">
                                                 <input type="checkbox" class="form-check-input" id="edit_checkbox_{{ event.id }}" name="checkbox" onclick="toggle_limit_edit({{ event.id }})" {% if event.list_limit != -1 %} checked {% endif %}>
-                                                <label class="form-check-label" for="new_checkbox">Limit list additions?</label>                            
+                                                <label class="form-check-label" for="checkbox">Limit list additions?</label>                            
                                             </div>
                                             <div class="form-group row">
                                                 <label for="new_limit" class="col-sm-2 col-form-label">List Limit</label>
@@ -231,6 +236,11 @@
                                 <div class="col-sm-10">
                                     <input type="text" class="form-control" id="new_location" name="location">
                                 </div>
+                            </div>
+                            <div class="form-group form-check">
+                                <input type="checkbox" class="form-check-input" id="new_public" name="public">
+                                <label class="form-check-label" for="new_public">Make event public?</label><br>
+                                <small>Making an event public will allow other organizations in your community to see the event on their calendar.</small>
                             </div>
                             <div class="form-group form-check">
                                 <input type="checkbox" class="form-check-input" id="new_checkbox" name="checkbox" onclick="toggle_limit()">

--- a/core/tests.py
+++ b/core/tests.py
@@ -15,13 +15,16 @@ from .tokens import *
 import re
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
+from tenant_schemas.test.cases import TenantTestCase
+from tenant_schemas.test.client import TenantClient
 
 
 # Create your tests here.
 
 # tests users signing in, out, and registering
-class AuthenticationTestCase(TestCase):
+class AuthenticationTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.u = User.objects.create(username="admin", is_superuser=True)
         self.client.force_login(self.u)
 
@@ -71,8 +74,9 @@ class AuthenticationTestCase(TestCase):
         self.assertContains(response, "Login")
 
 
-class SignupTestCase(TestCase):
+class SignupTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.form_data = {
             'username': 'test',
             'email': 'test@test.com',
@@ -256,8 +260,9 @@ class SignupTestCase(TestCase):
         self.assertFalse(user.check_password('xyzabc'))
         self.assertTrue(user.check_password('originalpassword'))
 
-class ResourcesTestCaseAdmin(TestCase):
+class ResourcesAdminTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.admin = User.objects.create(username="admin", is_superuser=True, is_staff=True)
         self.client.force_login(self.admin)
 
@@ -305,7 +310,8 @@ class ResourcesTestCaseAdmin(TestCase):
         path = reverse('upload_file')
         response = self.client.post(path, post_dict, follow=True)
         self.assertContains(response, 'filename')
-        path = reverse('remove_file', kwargs=dict(file_id=1))
+        file_object = ResourceFile.objects.get(name='filename')
+        path = reverse('remove_file', kwargs=dict(file_id=file_object.pk))
         response = self.client.post(path, follow=True)
         self.assertNotContains(response, 'filename')
 
@@ -357,15 +363,17 @@ class ResourcesTestCaseAdmin(TestCase):
     # tests remove link function
     def test_remove_link(self):
         ResourceLink.objects.create(name='test', description='test description', url='https://www.google.com')
-        path = reverse('remove_link', kwargs=dict(link_id=1))
+        link_object = ResourceLink.objects.get(name='test')
+        path = reverse('remove_link', kwargs=dict(link_id=link_object.pk))
         referer = reverse('resources')
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         self.assertFalse(ResourceLink.objects.all())
         self.assertFalse(re.findall("<h4.*test</h4", str(response.content)))
 
 
-class ResourcesTestCaseRegular(TestCase):
+class ResourcesTestCaseRegular(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.regular = User.objects.create(username="regular")
         self.client.force_login(self.regular)
         self.path = reverse('resources')
@@ -384,8 +392,9 @@ class ResourcesTestCaseRegular(TestCase):
         self.assertNotContains(self.response, "modal")
 
         
-class AnnouncementsTestCase(TestCase):
+class AnnouncementsTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         u = User.objects.create(username="admin", is_staff=True, is_superuser=True)
         self.client.force_login(u)
         a = Announcement.objects.create(user=u)
@@ -439,11 +448,12 @@ class AnnouncementsTestCase(TestCase):
         self.assertContains(response, 'titlebody')
 
 
-class SocialTestCase(TestCase):
+class SocialTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.admin = User.objects.create(username="admin", is_staff=True, is_superuser=True)
         self.client.force_login(self.admin)
-        SocialEvent.objects.create()
+        self.event = SocialEvent.objects.create()
         
     # tests that the social page exists with the proper header
     def test_social_home_template(self):
@@ -456,7 +466,7 @@ class SocialTestCase(TestCase):
     def test_event_on_home_page(self):
         path = reverse('social')
         response = self.client.post(path)
-        self.assertContains(response, '<a href="social_event1"')
+        self.assertContains(response, '<a href="social_event' + str(self.event.pk))
     
     # tests the create event function
     def test_create_event(self):
@@ -467,13 +477,13 @@ class SocialTestCase(TestCase):
 
     # tests that the page for an individual social event exists
     def test_social_event_page_exists(self):
-        path = reverse('social_event', kwargs=dict(event_id=1))
+        path = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path)
         self.assertEqual(response.status_code, 200)
     
     # tests that the social event page populates with relevant data
     def test_social_event_page_populates(self):
-        path = reverse('social_event', kwargs=dict(event_id=1))
+        path = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path)
         content = str(response.content)
         self.assertTrue(re.findall('<h1.*test</h1>', content))
@@ -481,16 +491,16 @@ class SocialTestCase(TestCase):
 
     # tests the remove_social_event function
     def test_remove_social_event(self):
-        path = reverse('remove_social_event', kwargs=dict(event_id=1))
+        path = reverse('remove_social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, HTTP_REFERER=reverse('social'), follow=True)
         self.assertNotContains(response, "test_name -- Jan. 1, 2001, noon")
         self.assertRaises(SocialEvent.DoesNotExist, SocialEvent.objects.get, id=1)
 
     # tests that the add_to_list function works with both individual and multiple input
     def test_add_to_list_individual_and_multiple(self):
-        path = reverse('add_to_list', kwargs=dict(event_id=1))
+        path = reverse('add_to_list', kwargs=dict(event_id=self.event.pk))
         post_data = {'multiple_names': 'many_name1\nmany_name2\nmany_name3', 'name': 'individual_name'}
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, post_data, HTTP_REFERER=referer)
         self.assertTrue(Attendee.objects.filter(name="many_name1"))
         self.assertTrue(Attendee.objects.filter(name="many_name2"))
@@ -499,44 +509,46 @@ class SocialTestCase(TestCase):
 
     # tests that add_to_list function works with only individual input
     def test_add_to_list_individual(self):
-        path = reverse('add_to_list', kwargs=dict(event_id=1))
+        path = reverse('add_to_list', kwargs=dict(event_id=self.event.pk))
         post_data = {'multiple_names': '', 'name': 'individual_name'}
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, post_data, HTTP_REFERER=referer)
         self.assertTrue(Attendee.objects.filter(name="individual_name"))
         self.assertFalse(Attendee.objects.filter(name="many_name"))
 
     # tests that add_to_list function works with only multiple-name input
     def test_add_to_list_multiple(self):
-        path = reverse('add_to_list', kwargs=dict(event_id=1))
+        path = reverse('add_to_list', kwargs=dict(event_id=self.event.pk))
         post_data = {'multiple_names': 'many_name1\nmany_name2\nmany_name3', 'name': ''}
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, post_data, HTTP_REFERER=referer)
         self.assertTrue(Attendee.objects.filter(name="many_name1"))
         self.assertTrue(Attendee.objects.filter(name="many_name2"))
         self.assertTrue(Attendee.objects.filter(name="many_name3"))
         self.assertFalse(Attendee.objects.filter(name="individual_name"))
 
-class SocialEventTestCase(TestCase):
+class SocialEventTestCase(TenantTestCase):
     
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.admin = User.objects.create(username="admin", is_staff=True, is_superuser=True)
         self.client.force_login(self.admin)
-        SocialEvent.objects.create()
-        self.event = SocialEvent.objects.get(id=1)
+        self.event = SocialEvent.objects.create()
+        self.attendees = []
         for i in range(1, 4):
-            a = Attendee.objects.create(name="attendee" + str(i), user=self.admin, event=self.event)
+             a = Attendee.objects.create(name="attendee" + str(i), user=self.admin, event=self.event)
+             self.attendees.append(a)
         self.event.save()
 
     # tests remove_from_list feature to make sure attendees are removed from database and UI
     def test_remove_from_list(self):
-        path = reverse('remove_from_list', kwargs=dict(event_id=1, attendee_id=1))
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        path = reverse('remove_from_list', kwargs=dict(event_id=self.event.pk, attendee_id=self.attendees[0].pk))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         self.assertFalse(Attendee.objects.filter(name="attendee1"))
         self.assertFalse(re.findall("<td.*>attendee1</td>", str(response.content)))
         self.assertTrue(re.findall("<td.*>attendee2</td>", str(response.content)))
-        path = reverse('remove_from_list', kwargs=dict(event_id=1, attendee_id=2))
+        path = reverse('remove_from_list', kwargs=dict(event_id=self.event.pk, attendee_id=self.attendees[1].pk))
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         self.assertFalse(Attendee.objects.filter(name="attendee2"))
         self.assertFalse(re.findall("<td.*>attendee2</td>", str(response.content)))
@@ -544,8 +556,8 @@ class SocialEventTestCase(TestCase):
 
     # tests clear list feature
     def test_clear_list(self):
-        path = reverse('clear_list', kwargs=dict(event_id=1))
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        path = reverse('clear_list', kwargs=dict(event_id=self.event.pk))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         content = str(response.content)
         self.assertFalse(re.findall("<td>attendee[1-3]</td>", content))
@@ -553,27 +565,27 @@ class SocialEventTestCase(TestCase):
 
     # tests exporting a spreadsheet of attendees
     def test_export_xls(self):
-        path = reverse('export_xls', kwargs=dict(event_id=1))
+        path = reverse('export_xls', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path)
         self.assertEqual(response.get('Content-Type'), 'application/ms-excel')
-        self.assertEqual(response.get('Content-Disposition'), 'attachment; filename=1_attendance.xls')
+        self.assertEqual(response.get('Content-Disposition'), 'attachment; filename=' + str(self.event.pk) + '_attendance.xls')
 
     # tests adding single duplicate name to the list
     def test_add_individual_duplicate(self):
-        path = reverse('add_to_list', kwargs=dict(event_id=1))
+        path = reverse('add_to_list', kwargs=dict(event_id=self.event.pk))
         # should fail, because name is a duplicate
         post_data = {'multiple_names': '', 'name': 'attendee1'}
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, post_data, HTTP_REFERER=referer, follow=True)
         self.assertContains(response, " <b>The following name was not added to the list, because it is a duplicate:</b> attendee1")
         self.assertEqual(len(Attendee.objects.filter(name="attendee1")), 1)
 
     # tests adding multiple duplicate names to the list
     def test_add_multiple_duplicate(self):
-        path = reverse('add_to_list', kwargs=dict(event_id=1))
+        path = reverse('add_to_list', kwargs=dict(event_id=self.event.pk))
         # should fail, because both names are duplicates
         post_data = {'multiple_names': 'attendee1\nattendee2', 'name': ''}
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, post_data, HTTP_REFERER=referer, follow=True)
         self.assertContains(response, " <b>The following name was not added to the list, because it is a duplicate:</b> attendee1")
         self.assertContains(response, " <b>The following name was not added to the list, because it is a duplicate:</b> attendee2")
@@ -582,10 +594,10 @@ class SocialEventTestCase(TestCase):
     
     # tests adding multiple names where some are duplicates and some aren't
     def test_add_duplicates_and_new(self):
-        path = reverse('add_to_list', kwargs=dict(event_id=1))
+        path = reverse('add_to_list', kwargs=dict(event_id=self.event.pk))
         # one should fail, one should work
         post_data = {'multiple_names': 'attendee1\nattendee5', 'name': ''}
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, post_data, HTTP_REFERER=referer, follow=True)
         self.assertContains(response, "<b>The following name was not added to the list, because it is a duplicate:</b> attendee1")
         self.assertNotContains(response, "<b>The following name was not added to the list, because it is a duplicate:</b> attendee2")
@@ -595,7 +607,7 @@ class SocialEventTestCase(TestCase):
     # tests checking attendance feature
     def test_check_attendance(self):
         path = reverse('check_attendee')
-        a = Attendee.objects.get(id=1)
+        a = self.event.list.first()
         get_data = {'attendee_id': a.id}
         response = self.client.get(path, get_data)
         self.assertEqual(response.status_code, 200)
@@ -607,7 +619,7 @@ class SocialEventTestCase(TestCase):
         self.assertTrue(a.attended)
 
     def test_uncheck_attendance(self):
-        a = Attendee.objects.get(id=1)
+        a = self.event.list.first()
         a.attended = True
         a.save()
         path = reverse('check_attendee')
@@ -627,17 +639,17 @@ class SocialEventTestCase(TestCase):
         get_data = {'event_id': self.event.id}
         response = self.client.get(path, get_data)
         self.assertEqual(response.status_code, 200)
-        # response should be false for all three attendees, with ids from 1 to 3 inclusive
+        # response should be false for all three attendees
         self.assertJSONEqual(
             str(response.content, encoding='utf8'),
             {
-                str(1): False,
-                str(2): False,
-                str(3): False
+                str(self.attendees[0].pk): False,
+                str(self.attendees[1].pk): False,
+                str(self.attendees[2].pk): False
             }
         )
     
-    # tests refresh_attendees view when status of attendee changes, to ensure change is propogated
+    # tests refresh_attendees view when status of attendee changes, to ensure change is propagated
     def test_refresh_attendees_dynamic(self):
         path = reverse('refresh_attendees')
         get_data = {'event_id': self.event.id}
@@ -645,14 +657,14 @@ class SocialEventTestCase(TestCase):
         self.assertJSONEqual(
             str(response.content, encoding='utf8'),
             {
-                str(1): False,
-                str(2): False,
-                str(3): False
+                str(self.attendees[0].pk): False,
+                str(self.attendees[1].pk): False,
+                str(self.attendees[2].pk): False
             }
         )
 
         # change one of the attendees, to see if the refresh changes the JSON response
-        a = Attendee.objects.get(id=2)
+        a = Attendee.objects.get(id=self.attendees[1].pk)
         a.attended = True
         a.save()
 
@@ -660,16 +672,16 @@ class SocialEventTestCase(TestCase):
         self.assertJSONEqual(
             str(response.content, encoding='utf8'),
             {
-                str(1): False,
-                str(2): True,
-                str(3): False
+                str(self.attendees[0].pk): False,
+                str(self.attendees[1].pk): True,
+                str(self.attendees[2].pk): False
             }
         )
 
     # test toggle_party_mode view
     def test_toggle_party_mode_view(self):
         # event.party_mode is initially false, request should make it true
-        path = reverse('toggle_party_mode', kwargs=dict(event_id=1))
+        path = reverse('toggle_party_mode', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path)
         self.event.refresh_from_db()
         self.assertTrue(self.event.party_mode)
@@ -682,7 +694,7 @@ class SocialEventTestCase(TestCase):
     # test toggle_party_mode template
     def test_toggle_party_mode_template(self):
         # party mode should initially be false
-        referer = reverse('social_event', kwargs=dict(event_id=1))
+        referer = reverse('social_event', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(referer)
 
         # when party mode is off, the label by the button should say off
@@ -695,7 +707,7 @@ class SocialEventTestCase(TestCase):
         self.assertNotContains(response, "Attended")
 
         # set party mode to true
-        path = reverse('toggle_party_mode', kwargs=dict(event_id=1))
+        path = reverse('toggle_party_mode', kwargs=dict(event_id=self.event.pk))
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         
         # when party mode is on, the label by the button should say on
@@ -708,7 +720,10 @@ class SocialEventTestCase(TestCase):
         self.assertNotContains(response, "Type Full Name Here")
         
 
-class ErrorsTestCase(TestCase):
+class ErrorsTestCase(TenantTestCase):
+
+    def setUp(self):
+        self.client = TenantClient(self.tenant)
     
     # tests custom 404 page appears on 404 error
     def test_404_custom_page(self):
@@ -717,15 +732,9 @@ class ErrorsTestCase(TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn("The requested URL, " + path + " could not be found.", str(response.content))
 
-    # tests custom 500 error appears on 500 error
-    def test_500_custom_page(self):
-        request = self.client.request()
-        request.current_app = 'core'
-        response = handler500(request)
-        self.assertIn("Something went wrong on our end.  We\\\'re working hard to fix it.", str(response.content))
-
-class SearchTestCases(TestCase):
+class SearchTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.admin = User.objects.create(username="admin", is_staff=True, is_superuser=True)
         self.client.force_login(self.admin)
         file = SimpleUploadedFile("file.txt", b"file_content", content_type="text/plain")
@@ -772,15 +781,16 @@ class SearchTestCases(TestCase):
         self.assertContains(response, '0 results for <b>None</b>')
 
 
-class RosterTestCase(TestCase):
+class RosterTestCase(TenantTestCase):
     def setUp(self):
+        self.client = TenantClient(self.tenant)
         self.admin = User.objects.create(username="admin", is_superuser=True, is_staff=True)
         self.client.force_login(self.admin)
         self.roster = Roster.objects.create(title="test_roster")
     
     # tests roster view function
     def test_roster_view(self):
-        path = reverse('roster', kwargs=dict(roster_id=1))
+        path = reverse('roster', kwargs=dict(roster_id=self.roster.pk))
         response = self.client.get(path)
         self.assertContains(response, "test_roster</h1>")
 
@@ -792,8 +802,8 @@ class RosterTestCase(TestCase):
     
     # tests edit_roster view function
     def test_edit_roster_view(self):
-        path = reverse('edit_roster', kwargs=dict(roster_id=1))
-        referer = reverse('roster', kwargs=dict(roster_id=1))
+        path = reverse('edit_roster', kwargs=dict(roster_id=self.roster.pk))
+        referer = reverse('roster', kwargs=dict(roster_id=self.roster.pk))
         post_data = {
             'updated_members': 'test1\ntest2\ntest3'
         }
@@ -805,8 +815,8 @@ class RosterTestCase(TestCase):
 
     # tests editing roster with duplicates
     def test_edit_roster_duplicates(self):
-        path = reverse('edit_roster', kwargs=dict(roster_id=1))
-        referer = reverse('roster', kwargs=dict(roster_id=1))
+        path = reverse('edit_roster', kwargs=dict(roster_id=self.roster.pk))
+        referer = reverse('roster', kwargs=dict(roster_id=self.roster.pk))
         # contains duplicate of test1
         post_data = {
             'updated_members': 'test1\ntest2\ntest1'
@@ -823,9 +833,9 @@ class RosterTestCase(TestCase):
         
     # tests remove_from_roster function
     def test_remove_from_roster(self):
-        RosterMember.objects.create(name="test", roster=self.roster)
-        path = reverse('remove_from_roster', kwargs=dict(roster_id=1, member_id=1))
-        referer = reverse('roster', kwargs=dict(roster_id=1))
+        member = RosterMember.objects.create(name="test", roster=self.roster)
+        path = reverse('remove_from_roster', kwargs=dict(roster_id=self.roster.pk, member_id=member.pk))
+        referer = reverse('roster', kwargs=dict(roster_id=self.roster.pk))
         response = self.client.get(path, HTTP_REFERER=referer, follow=True)
         self.assertEqual(self.roster.members.count(), 0)
         self.assertNotContains(response, "test</td>")
@@ -925,7 +935,7 @@ class RosterTestCase(TestCase):
 
     # tests remove_roster function
     def test_remove_roster(self):
-        path = reverse('remove_roster', kwargs=dict(roster_id=1))
+        path = reverse('remove_roster', kwargs=dict(roster_id=self.roster.pk))
         referer = reverse('social')
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         self.assertNotContains(response, "test_roster</a>")

--- a/core/urls.py
+++ b/core/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path('activate/<int:user_id>/<str:token>', views.activate, name='activate'),
     path('forgot_credentials', views.forgot_credentials, name='forgot_credentials'),
     path('reset_password<int:user_id>/<str:token>', views.reset_password, name='reset_password'),
-    path('login/', LoginView.as_view(template_name='core/login.html', authentication_form=LoginForm), name="login"),
+    path('login/', views.CustomLoginView.as_view(template_name='core/login.html', authentication_form=LoginForm), name="login"),
     path('logout', views.logout_user, name='logout'),
     path('resources', views.resources, name="resources"),
     path('search', views.SearchView.as_view(), name="search"),

--- a/core/views.py
+++ b/core/views.py
@@ -382,6 +382,10 @@ def create_social_event(request):
         obj.date = request.POST.get('date')
         obj.time = request.POST.get('time')
         obj.location = request.POST.get('location')
+        if request.POST.get('public') == 'on':
+            obj.is_public = True
+        else:
+            obj.is_public = False
         if request.POST.get('limit') != None:
             if request.POST.get('limit') != '':
                 obj.list_limit = request.POST.get('limit')
@@ -401,6 +405,10 @@ def edit_social_event(request, event_id):
         obj.date = request.POST.get('date')
         obj.time = request.POST.get('time')
         obj.location = request.POST.get('location')
+        if request.POST.get('public') == 'on':
+            obj.is_public = True
+        else:
+            obj.is_public = False
         if request.POST.get('limit') != None:
             if request.POST.get('limit') != '':
                 obj.list_limit = request.POST.get('limit')

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -211,7 +211,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 if ENV == 'testing':
     MEDIA_URL = '/media/'
     MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-    DEFAULT_FILE_STORAGE = 'tenant_schemas.storage.TenantFileSystemStorage'
+    # DEFAULT_FILE_STORAGE = 'tenant_schemas.storage.TenantFileSystemStorage'   <-- should probably be set but haven't gotten it to work yet
 
 # AWS S3 for media upload hosting
 else:

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -36,7 +36,7 @@ if ENV == 'testing':
 else:
     DEBUG = False
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'greeklink-core-env.eba-7mntraig.us-west-2.elasticbeanstalk.com', 'test.localhost']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'greeklink-core-env.eba-7mntraig.us-west-2.elasticbeanstalk.com', 'test.localhost', 'test2.localhost']
 
 
 # Application definition
@@ -44,15 +44,15 @@ SHARED_APPS = (
     'tenant_schemas',
     'organizations',
     'django.contrib.contenttypes',
-    'django.contrib.auth',
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'django.contrib.sessions',
-    
 )
 
 TENANT_APPS = (
     'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'django.contrib.admin',
     'core',
     'rush',
     'cal',

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -18,6 +18,8 @@ environ.Env.read_env()
 
 ENV = os.environ['ENV']
 
+SITE_ID = 1
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEMPLATE_DIR = os.path.join(BASE_DIR, 'templates')
@@ -34,32 +36,50 @@ if ENV == 'testing':
 else:
     DEBUG = False
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'greeklink-core-env.eba-7mntraig.us-west-2.elasticbeanstalk.com']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'greeklink-core-env.eba-7mntraig.us-west-2.elasticbeanstalk.com', 'test.localhost']
 
 
 # Application definition
+SHARED_APPS = (
+    'tenant_schemas',
+    'organizations',
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'django.contrib.sites',
+    'django.contrib.staticfiles',
+    'django.contrib.sessions',
+    
+)
 
-MY_APPS = [
-    'core.apps.CoreConfig',
-    'rush.apps.RushConfig',
-    'cal.apps.CalConfig',
-]
+TENANT_APPS = (
+    'django.contrib.contenttypes',
+    'core',
+    'rush',
+    'cal',
+)
 
 INSTALLED_APPS = [
+    'tenant_schemas',
+    'organizations.apps.OrganizationsConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     'crispy_forms',
     'django_user_agents',
     'storages',
+    'core.apps.CoreConfig',
+    'rush.apps.RushConfig',
+    'cal.apps.CalConfig',
 ]
 
-INSTALLED_APPS += MY_APPS
+TENANT_MODEL = 'organizations.Client'
 
 MIDDLEWARE = [
+    'tenant_schemas.middleware.TenantMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -91,17 +111,21 @@ TEMPLATES = [
     },
 ]
 
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.core.context_processors.request',
+)
+
 WSGI_APPLICATION = 'greeklink_core.wsgi.application'
 
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-# aws postgres database in production
+# aws postgres database in production with multitenant support
 if 'RDS_DB_NAME' in os.environ:
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'tenant_schemas.postgresql_backend',
             'NAME': os.environ['RDS_DB_NAME'],
             'USER': os.environ['RDS_USERNAME'],
             'PASSWORD': os.environ['RDS_PASSWORD'],
@@ -113,11 +137,18 @@ if 'RDS_DB_NAME' in os.environ:
 else:
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+            'ENGINE': 'tenant_schemas.postgresql_backend',
+            'NAME': 'greeklinkdb',
+            'USER': 'greeklinkuser',
+            'PASSWORD': 'greeklink1',
+            'HOST': 'localhost',
+            'PORT': '',
         }
     }
 
+DATABASE_ROUTERS = (
+    'tenant_schemas.routers.TenantSyncRouter',
+)
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
@@ -180,6 +211,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 if ENV == 'testing':
     MEDIA_URL = '/media/'
     MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+    DEFAULT_FILE_STORAGE = 'tenant_schemas.storage.TenantFileSystemStorage'
 
 # AWS S3 for media upload hosting
 else:

--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/organizations/apps.py
+++ b/organizations/apps.py
@@ -1,0 +1,4 @@
+from django.apps import AppConfig
+
+class OrganizationsConfig(AppConfig):
+    name = 'organizations'

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -1,0 +1,18 @@
+from django.db import models
+from tenant_schemas.models import TenantMixin
+
+# Create your models here.
+
+class Client(TenantMixin):
+    """ represents an organization with their own schema
+        name -- name of the organization
+        community -- name of the community containing this client (ex. UVA)
+        paid_until -- end date as far as the group has paid for usage
+        created_on -- date created
+        auto_create_schema -- if True automatically creates a schema when new client is saved
+    """
+    name = models.CharField(max_length=100)
+    community = models.CharField(max_length=100)
+    paid_until = models.DateField()
+    created_on = models.DateField(auto_now_add=True)
+    auto_create_schema = True

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -13,6 +13,6 @@ class Client(TenantMixin):
     """
     name = models.CharField(max_length=100)
     community = models.CharField(max_length=100)
-    paid_until = models.DateField()
+    paid_until = models.DateField(blank=True, null=True)
     created_on = models.DateField(auto_now_add=True)
     auto_create_schema = True

--- a/organizations/models.py
+++ b/organizations/models.py
@@ -3,6 +3,12 @@ from tenant_schemas.models import TenantMixin
 
 # Create your models here.
 
+class Community(models.Model):
+    """ represents a community, which contains multiple Clients
+        name -- string representing the name of the community
+    """
+    name = models.CharField(max_length=100)
+
 class Client(TenantMixin):
     """ represents an organization with their own schema
         name -- name of the organization
@@ -12,7 +18,7 @@ class Client(TenantMixin):
         auto_create_schema -- if True automatically creates a schema when new client is saved
     """
     name = models.CharField(max_length=100)
-    community = models.CharField(max_length=100)
+    community = models.ForeignKey(Community, on_delete=models.CASCADE, related_name='clients', blank=True, null=True)
     paid_until = models.DateField(blank=True, null=True)
     created_on = models.DateField(auto_now_add=True)
     auto_create_schema = True

--- a/organizations/tests.py
+++ b/organizations/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ Django==2.1.1
 django-crispy-forms==1.9.0
 django-environ==0.4.5
 django-storages==1.9.1
+django-tenant-schemas==1.10.0
 django-user-agents==0.4.0
 docker==4.2.0
 docker-compose==1.25.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Django==2.1.1
 django-crispy-forms==1.9.0
 django-environ==0.4.5
 django-storages==1.9.1
-django-tenant-schemas==1.10.0
+django-tenant-schemas==1.9.0
 django-user-agents==0.4.0
 docker==4.2.0
 docker-compose==1.25.5

--- a/start-up.sh
+++ b/start-up.sh
@@ -16,7 +16,7 @@ sudo rm -rf media/
 
 # migrations and static files
 createdb greeklinkdb
-psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"
+psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser; ALTER USER greeklinkuser CREATEDB;"
 python manage.py makemigrations core
 python manage.py makemigrations organizations
 python manage.py makemigrations rush

--- a/start-up.sh
+++ b/start-up.sh
@@ -5,14 +5,18 @@ python3 -m venv env
 # activate virtual environment and install requirements
 source env/bin/activate && pip install -r requirements.txt
 # remove database and migrations
-sudo rm db.sqlite3
+dropdb greeklinkdb
 sudo rm -rf core/migrations
 sudo rm -rf rush/migrations
+sudo rm -rf organizations/migrations
+sudo rm -rf cal/migrations
 # migrations and static files
+createdb greeklinkdb
 python manage.py makemigrations core
+python manage.py makemigrations organizations
 python manage.py makemigrations rush
 python manage.py makemigrations cal
-python manage.py migrate
+python manage.py migrate_schemas
 python manage.py collectstatic --noinput
 
 # load fixtures

--- a/start-up.sh
+++ b/start-up.sh
@@ -16,7 +16,8 @@ sudo rm -rf media/
 
 # migrations and static files
 createdb greeklinkdb
-psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser; ALTER USER greeklinkuser CREATEDB;"
+psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1';"
+psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser; ALTER USER greeklinkuser CREATEDB;"
 python manage.py makemigrations core
 python manage.py makemigrations organizations
 python manage.py makemigrations rush

--- a/start-up.sh
+++ b/start-up.sh
@@ -26,7 +26,7 @@ python manage.py migrate_schemas
 python manage.py collectstatic --noinput
 
 # load fixtures
-echo "from organizations.models import Client; Client.objects.create(domain_url='test.localhost', schema_name='test', name='Test Tenant', community='test_community', paid_until='2100-12-31'); exit();" | python manage.py shell
+echo "from organizations.models import Client; Client.objects.create(domain_url='test.localhost', schema_name='test', name='Test Tenant', paid_until='2100-12-31'); Client.objects.create(domain_url='localhost', schema_name='public', name='public'); exit();" | python manage.py shell
 python manage.py tenant_command loaddata --schema=test auth.json
 python manage.py tenant_command loaddata --schema=test settings.json 
 

--- a/start-up.sh
+++ b/start-up.sh
@@ -12,6 +12,7 @@ sudo rm -rf organizations/migrations
 sudo rm -rf cal/migrations
 # migrations and static files
 createdb greeklinkdb
+psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"
 python manage.py makemigrations core
 python manage.py makemigrations organizations
 python manage.py makemigrations rush
@@ -20,5 +21,6 @@ python manage.py migrate_schemas
 python manage.py collectstatic --noinput
 
 # load fixtures
-python manage.py loaddata auth.json
-python manage.py loaddata settings.json
+echo "from organizations.models import Client; Client.objects.create(domain_url='test.localhost', schema_name='test', name='Test Tenant', community='test_community', paid_until='2100-12-31'); exit();" | python manage.py shell
+python manage.py tenant_command loaddata --schema=test auth.json
+python manage.py tenant_command loaddata --schema=test settings.json 

--- a/start-up.sh
+++ b/start-up.sh
@@ -10,6 +10,10 @@ sudo rm -rf core/migrations
 sudo rm -rf rush/migrations
 sudo rm -rf organizations/migrations
 sudo rm -rf cal/migrations
+
+# delete everything from media
+sudo rm -rf media/
+
 # migrations and static files
 createdb greeklinkdb
 psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"

--- a/start-up.sh
+++ b/start-up.sh
@@ -16,7 +16,7 @@ sudo rm -rf media/
 
 # migrations and static files
 createdb greeklinkdb
-psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"
+psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1'; GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser;"
 python manage.py makemigrations core
 python manage.py makemigrations organizations
 python manage.py makemigrations rush

--- a/start-up.sh
+++ b/start-up.sh
@@ -29,3 +29,5 @@ python manage.py collectstatic --noinput
 echo "from organizations.models import Client; Client.objects.create(domain_url='test.localhost', schema_name='test', name='Test Tenant', community='test_community', paid_until='2100-12-31'); exit();" | python manage.py shell
 python manage.py tenant_command loaddata --schema=test auth.json
 python manage.py tenant_command loaddata --schema=test settings.json 
+
+echo "Done!"


### PR DESCRIPTION
Reworks a lot of the architecture to support multitenant use of the database.
* First, this branch includes changing the database used in local testing to postgres.  This means that postgres will need to be running on your computer if you're using localhost to test.
  * These changes are reflected in the start-up.sh script as well as on travis
* Created the organizations app, which contains only one model.  This model, organizations.models.Client, represents a single student organization, which will have it's own schema on the database.  Creating or changing objects of this model creates a new tenant
* tenants can access the site at tenant_name.domain.com.  When you run start-up.sh a single tenant called 'test' will automatically be created, so to see the site you need to go to test.localhost:8000.  
* All of the tests were updated to reflect these changes
