### PR TITLE
Enables Django to interact with AWS Simple Email Service

### DIFF
--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -192,16 +192,19 @@ LOGIN_URL = '/login'
 LOGIN_REDIRECT_URL = '/'
 
 # email settings
+EMAIL_USE_TLS = True
+EMAIL_PORT = 587
+
 if ENV == 'testing':
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_USE_TLS = True
     EMAIL_HOST = 'smtp.gmail.com'
-    EMAIL_HOST_USER = 'greekrhoverify@gmail.com'
-    EMAIL_HOST_PASSWORD = 'greekrho1'
-    EMAIL_PORT = 587
+    EMAIL_HOST_USER = 'greeklinkverify@gmail.com'
+    EMAIL_HOST_PASSWORD = 'greeklink1'
 
-# else:  need to configure SMTP server wherever we host it
-
+# AWS SES access
+else:
+    EMAIL_BACKEND = 'django_ses.SESBackend'
+   
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -200,7 +200,6 @@ if ENV == 'testing':
     EMAIL_HOST = 'smtp.gmail.com'
     EMAIL_HOST_USER = os.environ['VERIFY_EMAIL']
     EMAIL_HOST_PASSWORD = os.environ['VERIFY_PASSWORD']
-    EMAIL_PORT = 587
 
     #other email settings
     ANN_EMAIL = os.environ['ANN_EMAIL']

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ wcwidth==0.1.9
 websocket-client==0.57.0
 xlwt==1.3.0
 zipp==3.1.0
+django-ses==1.0.2


### PR DESCRIPTION
Added a new requirement, django-ses, to use as the production environment email back end service.

Settings.py now uses the ses backend when the environment is not set to 'testing'. The authentication should be handled by the same keys used to access s3.