### PR TITLE
2021 rush

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -37,7 +37,6 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.shortcuts import render, redirect
 import datetime
 from django.contrib.auth.views import LoginView
-from django_ses.signals import bounce_received, complaint_received
 from django.dispatch import receiver
 from organizations.models import Client
 from rush.models import RushEvent

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,4 +53,3 @@ wcwidth==0.1.9
 websocket-client==0.57.0
 xlwt==1.3.0
 zipp==3.1.0
-django-ses[bounce]==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ cryptography==2.9.2
 Django==2.1.1
 django-crispy-forms==1.9.0
 django-environ==0.4.5
+django-ses==1.0.2
 django-storages==1.9.1
 django-tenant-schemas==1.9.0
 django-user-agents==0.4.0

--- a/rush/forms.py
+++ b/rush/forms.py
@@ -35,6 +35,9 @@ class RusheeForm(ModelForm):
     phone_number = forms.CharField(max_length=10,
         widget=forms.TextInput(attrs={'class': 'form-control rounded', 'placeholder': 'Phone Number'}))
 
+    in_person = forms.ChoiceField(choices={(True, 'Yes'), (False, 'No')}, label="Do you plan to participate in the in-person rush activities this year?",
+        widget=forms.Select(attrs={'class': 'form-control rounded'}))
+
     class Meta:
         model = Rushee
         fields = ['name', 'email', 'year', 'major', 'hometown', 'address', 'phone_number']

--- a/rush/models.py
+++ b/rush/models.py
@@ -43,6 +43,9 @@ class Rushee(models.Model):
     hometown = models.CharField(max_length=75)
     address = models.CharField(max_length=75)
     phone_number = models.CharField(max_length=10)
+
+    in_person = models.BooleanField(default=True)
+
     endorsements = models.ManyToManyField(User, related_name="endorsed_rushees", blank=True)
     oppositions = models.ManyToManyField(User, related_name="opposed_rushees", blank=True)
 

--- a/rush/templates/rush/rushee.html
+++ b/rush/templates/rush/rushee.html
@@ -215,6 +215,10 @@
                 <td>Phone Number</td>
                 <td>{{ rushee.phone_number }}</td>
             </tr>
+            <tr>
+                <td>In Person Rush?</td>
+                <td>{{ rushee.in_person }}</td>
+            </tr>
     </table>
 </div>
 
@@ -369,6 +373,10 @@
             <tr>
                 <td>Phone</td>
                 <td>{{ rushee.phone_number }}</td>
+            </tr>
+            <tr>
+                <td>In Person Rush?</td>
+                <td>{{ rushee.in_person }}</td>
             </tr>
         </table>
     </div>

--- a/rush/templates/rush/signin.html
+++ b/rush/templates/rush/signin.html
@@ -12,6 +12,7 @@
 <br>
 {% endif %}
 {% if not settings.rush_signin_active %}
+<br>
 <div class="container">
     <div class="alert alert-danger">
     Rush signin is not active.  Must be enabled by site admin.
@@ -87,6 +88,7 @@
     </div>
     {% endif %}
 {% else %}
+<br>
 <div class="dropdown" style="margin-left: 5%">
     <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Change event
@@ -128,6 +130,10 @@
     </div>
     <div class="form-group">
         {{ form.phone_number }}
+    </div>
+    <div class="form-group">
+        <b>{{ form.in_person.label }}</b><br><br>
+        {{ form.in_person }}
     </div>
     <input type="hidden" id="profile_picture_data" name="profile_picture_data">
     <br>

--- a/rush/tests.py
+++ b/rush/tests.py
@@ -223,7 +223,8 @@ class RusheeRegisterTestCase(TenantTestCase):
             'major': 'test_major',
             'hometown': 'test_hometown',
             'address': 'test_address',
-            'phone_number': '9999999999'
+            'phone_number': '9999999999',
+            'in_person': True
         }
 
     def test_valid_form_register(self):

--- a/rush/views.py
+++ b/rush/views.py
@@ -112,7 +112,6 @@ def rushee(request, num):
 
 
 # adds a rushee to the database when they first sign in
-@login_required
 def register(request, event_id):
     """ adds a rushee to the database when they first sign in
         event_id -- primary key of event that rushee is registering in
@@ -165,7 +164,6 @@ def register(request, event_id):
 
 
 # for rushees signing into events
-@login_required
 def signin(request, event_id=-1):
     """ page for rushees signing into events when they are already registered
         event_id -- if passed in URL represents the event being signed into


### PR DESCRIPTION
* Made the rush signin page accessible without logging in.  This is to accommodate remote rush, where rushees won't be able to attend open houses to sign up for rush.

* Added a field to the rushee model and a select option on the rush signin form to track whether a rushee plans to be rushing in person