### PR TITLE
Dockerize local database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,6 @@ __pycache__/
 # ignore virtual env
 env/
 
-# ingore environment variables file
-.env
-
 # ignore migrations, static, and media directories
 # (static is recollected in start-up.sh)
 db.sqlite3

--- a/README.md
+++ b/README.md
@@ -19,19 +19,8 @@ To install the project locally, run the following commands from your command lin
 git clone https://github.com/csyager/greeklink-core.git
 cd greeklink-core
 ```
-For some functionality, as well as to protect secret keys, we use a .env file.  This file is stored in the greeklink_core directory.  Use a text editor to open the .env-template file (note that the file may be hidden).  Change the line that starts with `DJANGO_SECRET_KEY=` to store a 50-character secret key for your app.  When this is done, change the name of the file from .env-template to .env.
-
 ## Dependencies
-To install the python virtual environment, start it, and install the dependencies for the application, run
-```
-python3 -m venv env
-source env/bin/activate
-pip install -r requirements.txt
-```
-
-In production, we run on a Postgres database.  You'll need to have Postgres installed locally for testing.  Postgres can be downloaded from [https://www.postgresql.org/download/](https://www.postgresql.org/download/), or via a package manager.  You may also want to download pgAdmin 4, a user interface for interacting with Postgres databases that runs in your browser.  pgAdmin 4 can be downloaded [here](https://www.pgadmin.org/download/).
-
-Included in the project is a script, `start-up.sh`.  This will install all dependencies and reset and configure your local Postgres database, as well as load fixtures that will pre-populate your local database with entries that will be necessary for interacting with the site.  In production, we use a practice called multitenancy that allows us to use subdomains and separate Postgres schemas so multiple organizations can share our server space.  The `start-up.sh` script will initialize a test tenant in your local database.
+Included in this project is a script, `start-up.sh`.  This will initialize a python virtual environment, remove any applied migrations and media files, start a clean docker image running the local postgres database, apply migrations, collect static files, and load the starting fixtures with entires that will be necessary for interacting with the site.  In production, we use a practice called multitenancy that allows us to use subdomains and separate Postgres schemas so multiple organizations can share our server space.  The `start-up.sh` script will initialize a test tenant in your local database.
 
 ## Running Locally
 
@@ -47,9 +36,9 @@ Use these credentials to sign into the application and view changes made to the 
 Django comes with several boilerplate scripts, a few of which need to be adjusted slightly to support multitenancy.
 
 * `python manage.py runserver` - starts the Django webserver locally
-* `python manage.py tenant-commands shell --schema=test` - starts the Django shell in the terminal, allowing you to view and interact with database objects in a Python environment.  The schema parameter should be set to whatever schema you're working with.
+* `python manage.py tenant-command shell --schema=test` - starts the Django shell in the terminal, allowing you to view and interact with database objects in a Python environment.  The schema parameter should be set to whatever schema you're working with.
 * `python manage.py makemigrations [app name]` - Compiles any changes made to models.py in an app.  Leaving the app name parameter empty compiles all of them.
-* `python manage.py migrate` - migrates changes compiled by makemigrations into the database.
+* `python manage.py migrate_schemas` - migrates changes compiled by makemigrations into the database.
 * `python manage.py collectstatic` - collects static files from each sub-directory and compiles them into the central /static directory.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This app is built using Django, a Python MVC framework that makes building a ser
 ### Requirements
 * Python 3.6
 * git
-* Postgresql
-
+* Docker
+ 
 To install the project locally, run the following commands from your command line interface:
 ```
 git clone https://github.com/csyager/greeklink-core.git

--- a/greeklink_core/.env
+++ b/greeklink_core/.env
@@ -1,0 +1,5 @@
+ENV='testing'
+VERIFY_EMAIL='verify@greek-rho.com'
+ANN_EMAIL='announcements@greek-rho.com'
+SUPPORT_EMAIL='support@greek-rho.com'
+EMAIL_HOST_USER='noreply@greek-rho.com'

--- a/greeklink_core/.env-template
+++ b/greeklink_core/.env-template
@@ -1,2 +1,0 @@
-DJANGO_SECRET_KEY='[insert secret key here!]'
-ENV='testing'

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 import environ
-from django.utils.crypto import get_random_secret_key
+from django.core.management.utils  import get_random_secret_key
 
 env = environ.Env()
 environ.Env.read_env()

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 import environ
+from django.utils.crypto import get_random_secret_key
 
 env = environ.Env()
 environ.Env.read_env()
@@ -28,7 +29,11 @@ TEMPLATE_DIR = os.path.join(BASE_DIR, 'templates')
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+if ENV == 'production':
+    SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+else:
+    # if not in production, use a randomly generated key
+    SECRET_KEY = get_random_secret_key()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if ENV == 'testing':
@@ -221,8 +226,10 @@ AWS_SES_AUTOTHROTTLE = 0.75
 VERIFY_EMAIL_USER = os.environ['VERIFY_EMAIL']
 SUPPORT_EMAIL_USER = os.environ['SUPPORT_EMAIL']
 ANN_EMAIL = os.environ['ANN_EMAIL']
-AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
-AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
+
+if ENV == 'production':
+    AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
+    AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
 
 
 # Static files (CSS, JavaScript, Images)

--- a/shut-down.sh
+++ b/shut-down.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker stop greekrho-postgres; 

--- a/start-up.sh
+++ b/start-up.sh
@@ -4,8 +4,8 @@
 python3 -m venv env
 # activate virtual environment and install requirements
 source env/bin/activate && pip install -r requirements.txt
-# remove database and migrations
-# sudo su - postgres -c "dropdb greeklinkdb"
+
+# remove migrations
 sudo rm -rf core/migrations
 sudo rm -rf rush/migrations
 sudo rm -rf organizations/migrations

--- a/start-up.sh
+++ b/start-up.sh
@@ -5,7 +5,7 @@ python3 -m venv env
 # activate virtual environment and install requirements
 source env/bin/activate && pip install -r requirements.txt
 # remove database and migrations
-dropdb greeklinkdb
+# sudo su - postgres -c "dropdb greeklinkdb"
 sudo rm -rf core/migrations
 sudo rm -rf rush/migrations
 sudo rm -rf organizations/migrations
@@ -14,10 +14,36 @@ sudo rm -rf cal/migrations
 # delete everything from media
 sudo rm -rf media/
 
+# stop database container if running
+docker stop greekrho-postgres || true
+
+# wait for database container to be stopped
+while docker ps -f name=greekrho-postgres | grep greekrho-postgres; do
+	sleep 0.1;
+done;
+
+# configure docker postgres db
+# username: greeklinkuser
+# password: greeklinkdb
+# host: localhost (127.0.0.1)
+# port: 5432
+docker run \
+	-d \
+	-P \
+	--env POSTGRES_HOST_AUTH_METHOD=trust \
+	--env POSTGRES_USER=greeklinkuser \
+	--env POSTGRES_DB=greeklinkdb \
+	-p 5432:5432 \
+	--rm \
+	--name greekrho-postgres \
+	postgres:latest 
+
+# wait until database container is ready to accept connections
+until pg_isready -h localhost -p 5432 -U greeklinkuser -d greeklinkdb; do
+	sleep 1.0;
+done;
+
 # migrations and static files
-createdb greeklinkdb
-psql -d postgres -c "CREATE USER greeklinkuser WITH PASSWORD 'greeklink1';"
-psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE greeklinkdb TO greeklinkuser; ALTER USER greeklinkuser CREATEDB;"
 python manage.py makemigrations core
 python manage.py makemigrations organizations
 python manage.py makemigrations rush


### PR DESCRIPTION
Installing and configuring postgres locally to run the test database is really painful.  This PR changes the local start-up scripts to run the local database in a docker container.  This should greatly simplify bootstrapping your local environment.

Also took out some of the unnecessary secrets in the .env file, so we don't have to use the painful process of using the .env-template thing anymore

Closes #125 