### PR TITLE
Social Pagination Bug Fix

### DIFF
--- a/core/templates/core/social.html
+++ b/core/templates/core/social.html
@@ -15,14 +15,34 @@
     <div class="container">
         <ul class="nav nav-tabs" id="social_tabs" role="tablist">
             <li class="nav-item">
-                <a class="nav-link active" id="events-tab" data-toggle="tab" href="#events" role="tab" aria-controls="events" aria-selected="true">Events</a>
+                <a class="nav-link {% if show_tab == "events" %} active {% endif %}" id="events-tab" data-toggle="tab" href="#events" role="tab" aria-controls="events" aria-selected="true">Events</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" id="rosters-tab" data-toggle="tab" href="#rosters" role="tab" aria-controls="rosters" aria-selected="true">Rosters</a>
+                <a class="nav-link {% if show_tab == "rosters" %} active {% endif %}" id="rosters-tab" data-toggle="tab" href="#rosters" role="tab" aria-controls="rosters" aria-selected="true">Rosters</a>
             </li>
+            <script>
+                $("#rosters-tab").click(function() {
+                    $.ajax({
+                        url: 'update_social_tab_session',
+                        data: {
+                          'social_tab': 'rosters'
+                        },
+                        dataType: 'json',
+                      });
+                })
+                $("#events-tab").click(function() {
+                    $.ajax({
+                        url: 'update_social_tab_session',
+                        data: {
+                          'social_tab': 'events'
+                        },
+                        dataType: 'json',
+                      });
+                })
+            </script>
         </ul>
         <div class="tab-content" id="social_tab_content">
-            <div class="tab-pane fade show active" id="events" role="tabpanel" aria-labelledby="events-tab">
+            <div class="tab-pane fade {% if show_tab == "events" %} show active {% endif %}" id="events" role="tabpanel" aria-labelledby="events-tab">
                 <br>
                 <h2>Events</h2>
                 <ul class="list-group">
@@ -40,7 +60,7 @@
                         }
             
                     </script>
-                    {% if not page_obj %}
+                    {% if not event_page_obj %}
                     <b><i>No events to display.  Social Events are tools to manage attendance at public events and can be created by administrators and will appear here.</i></b>
                     {% endif %}
                     {% if upcoming_events %}
@@ -197,15 +217,56 @@
                 {% if perms.core.add_socialevent %}
                 <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#eventModal"><i class="fa fa-plus" aria-hidden="true"></i> Add Event</button>
                 {% endif %}
+                {% if eventscount > 10 %}
+                    <div class="container">
+                        <div class='row title-row my-1'>
+                            <div class='col-12 py-1'>
+                                <nav aria-label="Page navigation">
+                                    <ul class="pagination justify-content-center">
+                                        {% if event_page_obj.has_previous %}
+
+                                        <li class ="page-item"><a class ="page-link" href="?eventspage={{ event_page_obj.previous_page_number }}">Previous</a></li>
+                                        {% else %}
+                                            <li class="page-item disabled">
+                                                <span class="page-link">Previous</span>
+                                            </li>
+                                        {% endif %}
+
+                                        {% for i in event_page_obj.paginator.page_range %}
+                                            {% if event_page_obj.number == i %}
+                                                <li class="page-item active">
+                                                    <a class="page-link" href="?eventspage={{ i }}">{{ i }}<span class="sr-only">(current)</span></a>
+                                                </li>
+                                            {% else %}
+                                                <li class="page-item"><a class="page-link" href="?eventspage={{ i }}">{{ i }}</a></li>
+
+                                            {% endif %}
+                                        {% endfor %}
+
+                                        {% if event_page_obj.has_next %}
+
+                                        <li class ="page-item"><a class ="page-link" href="?eventspage={{ event_page_obj.next_page_number }}">Next</a></li>
+
+                                        {% else %}
+                                        <li class="page-item disabled">
+                                            <span class="page-link">Next</span>
+                                        </li>
+                                        {% endif %}
+                                    </ul>
+                                </nav>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
-            <div class="tab-pane fade" id="rosters" role="tabpanel" aria-labelledby="rosters-tab">
+            <div class="tab-pane fade {% if show_tab == "rosters" %} show active {% endif %}" id="rosters" role="tabpanel" aria-labelledby="rosters-tab">
                 <br>
                 <h2>Rosters</h2>
                 <ul class="list-group">
                     {% if not rosters %}
                         <b><i>No rosters to display.  Rosters are lists containing names that can be created by administrators to be easily added to social event lists, and will appear here.</i></b>
                     {% endif %}
-                    {% for roster in rosters %}
+                    {% for roster in roster_page_obj %}
                         <li class="list-group-item"><a href="roster{{ roster.id }}">{{ roster.title }}</a>
                             {% if perms.core.delete_roster %}
                             <button class="btn btn-danger btn-sm float-right" data-toggle="modal" data-target="#remove_roster_modal{{ roster.id }}">Delete Roster</button>
@@ -274,7 +335,47 @@
                     </div>
                 </div>
                 {% endif %}
-            
+                {% if rosterscount > 10 %}
+                    <div class="container">
+                        <div class='row title-row my-1'>
+                            <div class='col-12 py-1'>
+                                <nav aria-label="Page navigation">
+                                    <ul class="pagination justify-content-center">
+                                        {% if roster_page_obj.has_previous %}
+
+                                        <li class ="page-item"><a class ="page-link" href="?rostersspage={{ roster_page_obj.previous_page_number }}">Previous</a></li>
+                                        {% else %}
+                                            <li class="page-item disabled">
+                                                <span class="page-link">Previous</span>
+                                            </li>
+                                        {% endif %}
+
+                                        {% for i in roster_page_obj.paginator.page_range %}
+                                            {% if roster_page_obj.number == i %}
+                                                <li class="page-item active">
+                                                    <a class="page-link" href="?rosterspage={{ i }}">{{ i }}<span class="sr-only">(current)</span></a>
+                                                </li>
+                                            {% else %}
+                                                <li class="page-item"><a class="page-link" href="?rosterspage={{ i }}">{{ i }}</a></li>
+
+                                            {% endif %}
+                                        {% endfor %}
+
+                                        {% if roster_page_obj.has_next %}
+
+                                        <li class ="page-item"><a class ="page-link" href="?rosterspage={{ roster_page_obj.next_page_number }}">Next</a></li>
+
+                                        {% else %}
+                                        <li class="page-item disabled">
+                                            <span class="page-link">Next</span>
+                                        </li>
+                                        {% endif %}
+                                    </ul>
+                                </nav>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         </div>
         <br>
@@ -371,46 +472,5 @@
     <br>
     <br>
 </div>
-{% if eventscount > 10 %}
-<div class="container">
-    <div class='row title-row my-1'>
-        <div class='col-12 py-1'>
-            <nav aria-label="Page navigation">
-                <ul class="pagination justify-content-center">
-        {% if page_obj.has_previous %}
 
-        <li class ="page-item"><a class ="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
-        {% else %}
-            <li class="page-item disabled">
-                <span class="page-link">Previous</span>
-            </li>
-        {% endif %}
-
-        {% for i in page_obj.paginator.page_range %}
-                            {% if page_obj.number == i %}
-                                <li class="page-item active">
-                                <a class="page-link" href="?page={{ i }}">{{ i }}<span class="sr-only">(current)</span></a>
-                                </li>
-                        {% else %}
-                            <li class="page-item"><a class="page-link" href="?page={{ i }}">{{ i }}</a></li>
-
-                        {% endif %}
-                        {% endfor %}
-
-        {% if page_obj.has_next %}
-
-        <li class ="page-item"><a class ="page-link" href="?page={{ page_obj.next_page_number }}">Next</a></li>
-
-        {% else %}
-        <li class="page-item disabled">
-            <span class="page-link">Next</span>
-        </li>
-        {% endif %}
-    </ul>
-</nav>
-</div>
-</div>
-</div>
-
-{% endif %}
 {% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -794,6 +794,14 @@ class RosterTestCase(TenantTestCase):
         response = self.client.get(path)
         self.assertContains(response, "test_roster</a>")
     
+    # tests that rosters are paginated if more than 10
+    def test_roster_paginates_over_ten(self):
+        for i in range(15):
+            Roster.objects.create(title=str(i))
+        path = reverse('social')
+        response = self.client.get(path)
+        self.assertContains(response, "<a class=\"page-link\" href=\"?rosterspage")
+    
     # tests edit_roster view function
     def test_edit_roster_view(self):
         path = reverse('edit_roster', kwargs=dict(roster_id=self.roster.pk))
@@ -934,5 +942,3 @@ class RosterTestCase(TenantTestCase):
         response = self.client.post(path, HTTP_REFERER=referer, follow=True)
         self.assertNotContains(response, "test_roster</a>")
         self.assertFalse(Roster.objects.filter(id=1))
-
-    

--- a/core/urls.py
+++ b/core/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('removeCal', views.removeCal, name="removeCal"),
     path('removeFile<int:file_id>', views.remove_file, name="remove_file"),
     path('social', views.social, name="social"),
+    path('update_social_tab_session', views.update_social_tab_session, name="update_social_tab_session"),
     path('createSocialEvent', views.create_social_event, name="create_social_event"),
     path('social_event<int:event_id>', views.social_event, name="social_event"),
     path('removeSocialEvent<int:event_id>', views.remove_social_event, name="remove_social_event"),

--- a/core/views.py
+++ b/core/views.py
@@ -414,27 +414,47 @@ def social(request):
     events = chain(upcoming, past)
     events = list(events)                                                           #converts to list, necessary for paginator
     # events = SocialEvent.objects.all().order_by('-date', 'time')                  lets keep this just in case something goes wrong with the query chain
-    rosters = Roster.objects.all()
+    rosters = list(Roster.objects.all())
 
-    #for pagination
-    paginator = Paginator(events, 10)                                               #this number changes items per page
-    page_number = request.GET.get('page')
-    page_obj = paginator.get_page(page_number)
+    # event pagination
+    event_paginator = Paginator(events, 10)                                               #this number changes items per page
+    event_page_number = request.GET.get('eventspage')
+    event_page_obj = event_paginator.get_page(event_page_number)
     eventscount = len(events)
-    upcoming_list = list(filter(lambda el: el in upcoming, page_obj))
-    past_list = list(filter(lambda el: el in past, page_obj))
+    upcoming_list = list(filter(lambda el: el in upcoming, event_page_obj))
+    past_list = list(filter(lambda el: el in past, event_page_obj))
+
+    # roster pagination
+    roster_paginator = Paginator(rosters, 10)
+    roster_page_number = request.GET.get('rosterspage')
+    roster_page_obj = roster_paginator.get_page(roster_page_number)
+    rosterscount = len(rosters)
+    
+    try:
+        show_tab = request.session['social_tab']
+    except KeyError:
+        show_tab = 'events'
 
     context = {
         'settings': getSettings(),
         'social_page': "active",
-        'page_obj': page_obj,
+        'event_page_obj': event_page_obj,
         'upcoming_events': upcoming_list,
         'past_events': past_list,
         'eventscount' : eventscount,
         'rosters': rosters,
+        'roster_page_obj': roster_page_obj,
+        'rosterscount': rosterscount,
         'social_event_form': SocialEventForm,
+        'show_tab': show_tab
     }
     return HttpResponse(template.render(context, request))
+
+
+@login_required
+def update_social_tab_session(request):
+    request.session['social_tab'] = request.GET.get('social_tab')
+    return HttpResponse()
 
 
 @permission_required('core.add_socialevent')


### PR DESCRIPTION
* created separate pagination for events and rosters
* moved pagination into the tab, this was previously causing confusion between the two lists.  This made using the tool with more than 10 events difficult to impossible
* added ajax to update session to keep track of which tab is open.  Previously would default to events on every reload

Closes #129 