### PR TITLE
Delete Rushee profile pic from S3 on rushee delete

### DIFF
--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -47,16 +47,12 @@ ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.localhost', '.elasticbeanstalk.com'
 import requests
 EC2_PRIVATE_IP = None
 try:
-    print("Trying to get health check IP address from EC2 meta-data")
     EC2_PRIVATE_IP = requests.get('http://169.254.169.254/latest/meta-data/local-ipv4', timeout=0.1).text
-    print(f"EC2_PRIVATE_IP: {EC2_PRIVATE_IP}")
 except requests.exceptions.RequestException:
     pass
 
 if EC2_PRIVATE_IP:
     ALLOWED_HOSTS.append(EC2_PRIVATE_IP)
-
-
 
 # Application definition
 SHARED_APPS = (

--- a/rush/models.py
+++ b/rush/models.py
@@ -3,6 +3,8 @@
 from django.db import models
 from core.models import User, OrgEvent
 from django.urls import reverse
+from django.dispatch import receiver
+
 
 YEAR_CHOICES = (
     (1, 'Freshman'),
@@ -69,6 +71,13 @@ class Rushee(models.Model):
 
     def __str__(self):
         return self.name
+
+
+@receiver(models.signals.pre_delete, sender=Rushee)
+def delete_s3_image(sender, instance, **kwargs):
+    if instance.profile_picture:
+        instance.profile_picture.delete(save=False)
+
 
 class Comment(models.Model):
     """ a comment left by a User on a rushee


### PR DESCRIPTION
Currently rushee profile pics aren't deleted from S3 when a rushee is deleted.  This will inevitably cause bloating as we expand.

Also removes some useless logging.

Closes #123 