### PR TITLE
134 Installation Cleanup

### DIFF
--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -152,10 +152,10 @@ elif os.environ.get('TRAVIS'):
     DATABASES = {
         'default': {
             'ENGINE': 'tenant_schemas.postgresql_backend',
-            'NAME': 'github_actions',
-            'USER': 'postgres',
-            'PASSWORD': 'postgres',
-            'HOST': '127.0.0.1',
+            'NAME': 'greeklinkdb',
+            'USER': 'greeklinkuser',
+            'PASSWORD': 'greeklink1',
+            'HOST': 'localhost',
             'PORT': '5432',
         }
     }

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -168,7 +168,7 @@ else:
             'USER': 'greeklinkuser',
             'PASSWORD': 'greeklink1',
             'HOST': 'localhost',
-            'PORT': '',
+            'PORT': '5433',
         }
     }
 

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -147,8 +147,8 @@ if 'RDS_DB_NAME' in os.environ:
             'PORT': os.environ['RDS_PORT'],
         }
     }
-# in github ci
-elif os.environ.get('GITHUB_WORKFLOW'):
+# running in Travis CI
+elif os.environ.get('TRAVIS'):
     DATABASES = {
         'default': {
             'ENGINE': 'tenant_schemas.postgresql_backend',

--- a/scripts/start-up.sh
+++ b/scripts/start-up.sh
@@ -33,7 +33,7 @@ docker run \
 	--env POSTGRES_HOST_AUTH_METHOD=trust \
 	--env POSTGRES_USER=greeklinkuser \
 	--env POSTGRES_DB=greeklinkdb \
-	-p 5432:5432 \
+	-p 5433:5432 \
 	--rm \
 	--name greekrho-postgres \
 	postgres:latest 

--- a/scripts/start-up.sh
+++ b/scripts/start-up.sh
@@ -39,7 +39,7 @@ docker run \
 	postgres:latest 
 
 # wait until database container is ready to accept connections
-until pg_isready -h localhost -p 5432 -U greeklinkuser -d greeklinkdb; do
+until docker exec greekrho-postgres pg_isready -h localhost -p 5432 -U greeklinkuser -d greeklinkdb; do
 	sleep 1.0;
 done;
 


### PR DESCRIPTION
* Moves the local docker image to port 5433 to prevent conflicts with a locally running postgres server.
* Moves the pg_isready command into the docker image instead of from the host machine.  This *should* remove the need to have postgres installed to run the startup script.