### PR TITLE
editing rush events and changed words on some forms

### DIFF
--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -84,7 +84,7 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                            <button type="submit" class="btn btn-primary">Save changes</button>
+                            <button type="submit" class="btn btn-primary">Create Announcement</button>
                             </form>
                         </div>
                     </div>

--- a/core/templates/core/social.html
+++ b/core/templates/core/social.html
@@ -461,7 +461,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                        <button type="submit" class="btn btn-primary">Save changes</button>
+                        <button type="submit" class="btn btn-primary">Create Event</button>
                         </form>
                     </div>
                 </div>

--- a/rush/templates/rush/events.html
+++ b/rush/templates/rush/events.html
@@ -54,7 +54,7 @@
                                     <div class="form-group row">
                                         <label for="new_event_round" class="col-sm-2 col-form-label">Round</label>
                                         <div class="col-sm-10">
-                                            <select class="form-control" id="edit_event_round {{ event.id}}" name="round" value="{{ event.round }}">
+                                            <select class="form-control" id="edit_event_round {{ event.id}}" name="round" value="{{ event.round }}" required>
                                                 {% for num in round_range %}
                                                 <option>{{ num }}</option>
                                                 {% endfor %}
@@ -70,7 +70,7 @@
                                     <div class="form-group row">
                                         <label for="new_location" class="col-sm-2 col-form-label">Location</label>
                                         <div class="col-sm-10">
-                                            <input type="text" class="form-control" id="edit_location_{{ event.id }}" name="location" value="{{ event.location }}" required>
+                                            <input type="text" class="form-control" id="edit_location_{{ event.id }}" name="location" value="{{ event.location }}">
                                         </div>
                                     </div>
                                     <div class="form-check">
@@ -111,19 +111,19 @@
                         <div class="form-group row">
                             <label for="new_name" class="col-sm-2 col-form-label">Name</label>
                             <div class="col-sm-10">
-                                <input type="text" class="form-control" id="new_name" name="name">
+                                <input type="text" class="form-control" id="new_name" name="name" required>
                             </div>
                         </div>
                         <div class="form-group row">
                             <label for="new_date" class="col-sm-2 col-form-label">Date</label>
                             <div class="col-sm-10">
-                                <input type="date" class="form-control" placeholder="YYYY-mm-dd" id="new_date" name="date">
+                                <input type="date" class="form-control" placeholder="YYYY-mm-dd" id="new_date" name="date" required>
                             </div>
                         </div>
                         <div class="form-group row">
                             <label for="new_event_round" class="col-sm-2 col-form-label">Round</label>
                             <div class="col-sm-10">
-                                <select class="form-control" id="new_event_round" name="round">
+                                <select class="form-control" id="new_event_round" name="round" required>
                                     {% for num in round_range %}
                                     <option>{{ num }}</option>
                                     {% endfor %}
@@ -133,7 +133,7 @@
                         <div class="form-group row">
                             <label for="new_time" class="col-sm-2 col-form-label">Time</label>
                             <div class="col-sm-10">
-                                <input type="time" class="form-control" id="new_time" placeholder="HH:mm:ss in 24-hour time" name="time">
+                                <input type="time" class="form-control" id="new_time" placeholder="HH:mm:ss in 24-hour time" name="time" required>
                             </div>
                         </div>
                         <div class="form-group row">

--- a/rush/templates/rush/events.html
+++ b/rush/templates/rush/events.html
@@ -3,6 +3,15 @@
 <br>
 <div class="container">
     <h2>Rush Events</h2>
+    {% if messages %}
+        {% for message in messages %}
+            {% if message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
+                <div class="alert alert-success">{{ message }}</div>
+            {% elif messages.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
+                <div class="alert alert-danger">{{ mesage }}</div>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
     <div class="list-group">
         {% if not events %}
             <b><i>No rush events to display.  Rush events can be created by admins, and track attendance of invited rushees.</i></b>
@@ -13,6 +22,72 @@
                 <a href="/rush/events/{{ event.id }}">{{ event.name }} -- {{ event.date }}, {{ event.time }} <span class="badge badge-info">{{ event.attendance.count }}</span></a>
                 {% if perms.rush.deleterushevent %}
                     <a href="removeEvent{{ event.id }}" class="btn btn-danger btn-sm float-right">Remove</a>
+                {% endif %}
+                {% if perms.rush.edit_rushevent %}
+                <button type="button" class="btn btn-secondary btn-sm float-right mr-1" data-toggle="modal" data-target="#editeventModal{{ event.id }}">Edit</button>
+
+                <!-- Modal -->
+                <div class="modal fade" id="editeventModal{{ event.id }}" tabindex="-1" role="dialog" aria-labelledby="editeventModal" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4 class="modal-title" id="eventModalLabel"> Edit Event</h4>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <form method="post" action="editEvent{{ event.id }}">
+                                    {% csrf_token %}
+                                    <div class="form-group row">
+                                        <label for="new_name" class="col-sm-2 col-form-label">Name</label>
+                                        <div class="col-sm-10">
+                                            <input type="text" class="form-control" id="edit_name_{{ event.id }}" name="name" value="{{ event.name }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="new_date" class="col-sm-2 col-form-label">Date</label>
+                                        <div class="col-sm-10">
+                                            <input type="date" class="form-control" id="edit_date_{{ event.id }}" placeholder="YYYY-mm-dd" name="date" value="{{ event.date|date:'Y-m-d' }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="new_event_round" class="col-sm-2 col-form-label">Round</label>
+                                        <div class="col-sm-10">
+                                            <select class="form-control" id="edit_event_round {{ event.id}}" name="round" value="{{ event.round }}">
+                                                {% for num in round_range %}
+                                                <option>{{ num }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="new_time" class="col-sm-2 col-form-label">Time</label>
+                                        <div class="col-sm-10">
+                                            <input type="time" class="form-control" id="edit_time_{{ event.id }}" name="time" placeholder="HH:mm:ss in 24-hour time" value="{{ event.time|date:'H:i' }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="new_location" class="col-sm-2 col-form-label">Location</label>
+                                        <div class="col-sm-10">
+                                            <input type="text" class="form-control" id="edit_location_{{ event.id }}" name="location" value="{{ event.location }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="form-check">
+                                        <input type="checkbox" class="form-check-input" id="edit_new_new_rushees" name="new_rushees" {% if event.new_rushees_allowed %} checked {% endif %}>
+                                        <label for="new_new_rushees" class="form-check-label">New Rushees Allowed?</label>
+                                    </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                <button type="submit" class="btn btn-primary">Save changes</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <br>
+                <br>
                 {% endif %}
             </li>
             {% endfor %}
@@ -74,7 +149,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                    <button type="submit" class="btn btn-primary">Save changes</button>
+                    <button type="submit" class="btn btn-primary">Create Event</button>
                     </form>
                 </div>
             </div>

--- a/rush/urls.py
+++ b/rush/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('events/<int:event_id>', views.event, name="event"),
     path('createEvent', views.create_event, name="create_event"),
     path('removeEvent<int:event_id>', views.remove_event, name="remove_event"),
+    path('editEvent<int:event_id>', views.edit_event, name="edit_event"),
     path('filter_rushees', views.filter_rushees, name="filter_rushees"),
     path('clear_rushees_filter', views.clear_rushees_filter, name="clear_rushees_filter"),
     path('toggle_rush_signin', views.toggle_rush_signin, name='toggle_rush_signin'),

--- a/rush/views.py
+++ b/rush/views.py
@@ -268,6 +268,27 @@ def create_event(request):
     else:
         raise Http404
 
+@permission_required('rush.edit_rushevent')
+def edit_event(request, event_id):
+    if request.method == 'POST':
+        obj = RushEvent.objects.get(id=event_id)
+        obj.name = request.POST.get('name')
+        obj.date = request.POST.get('date')
+        obj.time = request.POST.get('time')
+        obj.round = request.POST.get('round')
+        obj.location = request.POST.get('location')
+        if len(request.POST.getlist('new_rushees')) != 0:
+            obj.new_rushees_allowed = True
+        else:
+            obj.new_rushees_allowed = False
+        
+        obj.save()
+        messages.success(request, "Rush event " + obj.name + " has been successfully edited.")
+
+        return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+    else:
+        raise Http404
+
 @permission_required('rush.delete_rushevent')
 def remove_event(request, event_id):
     """ deletes a RushEvent object


### PR DESCRIPTION
Allows editing for rush events if you are admin. all aspects on the form are editable, including "new rushees allowed".


also changed some words on forms from "save changes" to things like "create announcement", "create event", etc. Editing forms keeps the "save changes" button.