### PR TITLE
Invite users via email

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
+from django.conf import settings
+from django.conf.urls import url
+from django.core.mail import send_mass_mail
+from django.contrib import messages
+from django.http import Http404, HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.template.loader import render_to_string
 from core.models import *
-from .forms import SiteSettingsForm
+from .forms import InviteUsersForm, SiteSettingsForm
 
 # Register your models here.
 admin.site.register(ResourceFile)
@@ -25,3 +32,58 @@ class SiteSettingsAdmin(admin.ModelAdmin):
 admin.site.register(SiteSettings, SiteSettingsAdmin)
 
 admin.site.site_header = "Greek-Rho Settings"
+
+class UserOpts():
+    object_name = "user"
+    app_label = "auth"
+    model_name = "user"
+
+class UserAdmin(admin.ModelAdmin):
+    change_list_template = "admin/user_change_list.html"
+
+    def get_urls(self):
+        base_urls = super(UserAdmin, self).get_urls()
+        additional_urls = [
+            url(r'^invite/$', self.admin_site.admin_view(self.invitation_configuration)),
+            url(r'^invite/send$', self.admin_site.admin_view(self.send_invitations))
+        ]
+        return additional_urls + base_urls
+    
+    def invitation_configuration(self, request):
+        context = dict(
+            self.admin_site.each_context(request),
+            add = False,
+            change = False,
+            save_as = False,
+            has_add_permission = False,
+            has_change_permission = False,
+            has_view_permission = False,
+            opts = UserOpts,
+            invite_users_form = InviteUsersForm
+        )
+        return TemplateResponse(request, "admin/user_invitation.html", context)
+
+    def send_invitations(self, request):
+        if request.method == 'POST':
+            recipients = request.POST.get('recipients')
+            message_list = []
+            tenant_name = request.tenant.name
+            title = f"Join {tenant_name} on GreekRho!"
+            truemessage = render_to_string('admin/invitation_email.html', {
+                'user': request.user.first_name + ' ' + request.user.last_name,
+                'organization': tenant_name,
+                'target': "https://" + request.tenant.domain_url + "/signup"
+            })
+            recipient_count = 0
+            for recipient in recipients.splitlines():
+                if recipient != "":
+                    recipient_count += 1
+                    message_list.append((title, truemessage, settings.EMAIL_HOST_USER, [recipient]))
+            send_mass_mail(message_list, fail_silently=True, auth_user=settings.EMAIL_HOST_USER)
+            messages.success(request, f"Success!  Email invitation has been sent to {recipient_count} recipients.")
+            return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+        else:
+            raise Http404
+  
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)

--- a/core/forms.py
+++ b/core/forms.py
@@ -194,3 +194,7 @@ class SupportForm(forms.Form):
         widget=forms.TextInput(attrs={'class': 'form-control rounded'})) 
     message = forms.CharField(required=True, max_length=500, label='Message:',
         widget=forms.Textarea(attrs={'class': 'form-control rounded', 'id': 'text_char_count'}))
+
+class InviteUsersForm(forms.Form):
+    recipients = forms.CharField(required=True, max_length=500, label="Recipients.  Separate each address by a newline.",
+        widget=forms.Textarea(attrs={'class': 'form-control rounded', 'cols': '50', 'rows': '4'}))

--- a/core/forms.py
+++ b/core/forms.py
@@ -196,5 +196,5 @@ class SupportForm(forms.Form):
         widget=forms.Textarea(attrs={'class': 'form-control rounded', 'id': 'text_char_count'}))
 
 class InviteUsersForm(forms.Form):
-    recipients = forms.CharField(required=True, max_length=500, label="Recipients.  Separate each address by a newline.",
+    recipients = forms.CharField(required=True, max_length=500, label="Email addresses of recipients.  Separate each address by a newline.",
         widget=forms.Textarea(attrs={'class': 'form-control rounded', 'cols': '50', 'rows': '4'}))

--- a/core/static/core/css/admin.css
+++ b/core/static/core/css/admin.css
@@ -1,0 +1,30 @@
+div.invite-users-form-container {
+    max-width: 500px;
+}
+
+#header {
+    background: #209CEE;
+    color: white;
+}
+
+#branding h1, #branding h1 a:link, #branding h1 a:visited {
+    color: white;
+}
+#user-tools a:focus, #user-tools a:hover {
+    text-decoration: none !important;
+    border-bottom-color: white !important;
+    color: white !important;
+}
+.module h2, .module caption, .inline-group h2 {
+    background: #209CEE;
+}
+.button.default, input[type=submit].default, .submit-row input.default {
+    background: #209CEE;
+}
+
+h1.admin-title {
+    font-family: "Roboto","Lucida Grande","DejaVu Sans","Bitstream Vera Sans",Verdana,Arial,sans-serif;
+    font-size: 20px;
+    font-weight: 300;
+    margin: 0 0 20px;
+}

--- a/core/static/core/css/style.css
+++ b/core/static/core/css/style.css
@@ -165,4 +165,4 @@ div.scrollable {
     margin-top: -30px;
     margin-right: 5px;
     position: relative;
-  }
+}

--- a/core/templates/admin/base.html
+++ b/core/templates/admin/base.html
@@ -1,24 +1,5 @@
 {% extends "admin/base.html" %}
 {% block extrastyle %}
-<style>
-    #header {
-        background: #209CEE;
-        color: white;
-    }
-
-    #branding h1, #branding h1 a:link, #branding h1 a:visited {
-        color: white;
-    }
-    #user-tools a:focus, #user-tools a:hover {
-        text-decoration: none !important;
-        border-bottom-color: white !important;
-        color: white !important;
-    }
-    .module h2, .module caption, .inline-group h2 {
-        background: #209CEE;
-    }
-    .button.default, input[type=submit].default, .submit-row input.default {
-        background: #209CEE;
-    }
-</style>
+{% load static %}
+<link rel="stylesheet" type="text/css" href="{% static 'core/css/admin.css' %}">
 {% endblock %}

--- a/core/templates/admin/invitation_email.html
+++ b/core/templates/admin/invitation_email.html
@@ -1,0 +1,8 @@
+{% autoescape off %}
+{{user}} has invited you to join {{organization}} on GreekRho.
+
+Click the link below to create your account.
+
+{{ target }}
+
+{% endautoescape %}

--- a/core/templates/admin/user_change_list.html
+++ b/core/templates/admin/user_change_list.html
@@ -1,0 +1,88 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_list %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+  {% if cl.formset %}
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+  {% endif %}
+  {% if cl.formset or action_form %}
+    <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+  {% endif %}
+  {{ media.css }}
+  {% if not actions_on_top and not actions_on_bottom %}
+    <style>
+      #changelist table thead th:first-child {width: inherit}
+    </style>
+  {% endif %}
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+{{ media.js }}
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
+&rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
+</div>
+{% endblock %}
+{% endif %}
+
+{% block coltype %}flex{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    {% block object-tools %}
+        <ul class="object-tools">
+          {% block object-tools-items %}
+            <li>
+                {% url cl.opts|admin_urlname:'invite' as invite_url %}
+                <a href="/admin/auth/user/invite" class="addlink">
+                {% blocktrans with cl.opts.verbose_name as name %}Invite Users{% endblocktrans %}
+                </a>
+            </li>
+            {% change_list_object_tools %}
+          {% endblock %}
+        </ul>
+    {% endblock %}
+    {% if cl.formset and cl.formset.errors %}
+        <p class="errornote">
+        {% if cl.formset.total_error_count == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+        </p>
+        {{ cl.formset.non_form_errors }}
+    {% endif %}
+    <div class="module{% if cl.has_filters %} filtered{% endif %}" id="changelist">
+      {% block search %}{% search_form cl %}{% endblock %}
+      {% block date_hierarchy %}{% if cl.date_hierarchy %}{% date_hierarchy cl %}{% endif %}{% endblock %}
+
+      {% block filters %}
+        {% if cl.has_filters %}
+          <div id="changelist-filter">
+            <h2>{% trans 'Filter' %}</h2>
+            {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
+          </div>
+        {% endif %}
+      {% endblock %}
+
+      <form id="changelist-form" method="post"{% if cl.formset and cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %} novalidate>{% csrf_token %}
+      {% if cl.formset %}
+        <div>{{ cl.formset.management_form }}</div>
+      {% endif %}
+
+      {% block result_list %}
+          {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+          {% result_list cl %}
+          {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+      {% endblock %}
+      {% block pagination %}{% pagination cl %}{% endblock %}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/core/templates/admin/user_invitation.html
+++ b/core/templates/admin/user_invitation.html
@@ -1,0 +1,72 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block extrahead %}{{ block.super }}
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+{{ media }}
+{% endblock %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+ <!-- bootstrap -->
+ <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+ <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+ <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+ <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+{% endblock %}
+
+{% block coltype %}colM{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-user model-user change-form{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="/admin/auth">Authentication and Authorization</a>
+&rsaquo; <a href="/admin/auth/user">Users</a></div>
+{% endblock %}
+{% endif %}
+
+{% block content %}<div id="content-main">
+<div>
+<form action="/admin/auth/user/invite/send" method="POST">
+{% csrf_token %}
+{% if errors %}
+    <p class="errornote">
+    {% if errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+    </p>
+    {{ adminform.form.non_field_errors }}
+{% endif %}
+
+{% block admin_change_form_document_ready %}
+    <script type="text/javascript"
+            id="django-admin-form-add-constants"
+            src="{% static 'admin/js/change_form.js' %}"
+            {% if adminform and add %}
+                data-model-name="user"
+            {% endif %}>
+    </script>
+{% endblock %}
+
+{# JavaScript for prepopulated fields #}
+{% prepopulated_fields_js %}
+
+</div>
+{% if message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
+<div class="alert alert-success" role="alert">
+    {{ message }}
+</div>
+{% endif %}
+<h1 class="admin-title">Invite Users</h1>
+{% for field in invite_users_form %}
+<div class="form-group invite-users-form-container">
+    <label>{{field.label}}</label>
+    {{ field }}
+</div>
+{% endfor %}
+<button class="btn btn-primary" type="submit">Submit</button>
+</form>
+</div>
+
+
+{% endblock %}

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -224,6 +224,7 @@ EMAIL_BACKEND = 'django_ses.SESBackend'
 AWS_SES_AUTOTHROTTLE = 0.75
 VERIFY_EMAIL_USER = os.environ['VERIFY_EMAIL']
 SUPPORT_EMAIL_USER = os.environ['SUPPORT_EMAIL']
+EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
 ANN_EMAIL = os.environ['ANN_EMAIL']
 
 if ENV == 'production':


### PR DESCRIPTION
Adds a page to the admin site to invite users via email.  Overrides the admin User page to include the `Invite Users` button on the top right, as well as new urls and views to handle the form and submission.

The page can be accessed from the index via `Site Settings -> Users -> Invite Users` (button on the top right).

Sends an email to each address in the form field, separated by a newline.  The email contains a link to the signup page for the organization sending the message.