### PR TITLE
Rush improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.6
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: psycopg2 prerequisites
       run: sudo apt-get install libpq-dev
     - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ botocore==1.23.31
 cached-property==1.5.1
 cement==2.8.2
 certifi==2020.4.5.1
-cffi==1.14.0
+cffi==1.15.1
 chardet==3.0.4
 charset-normalizer==2.0.10
 colorama==0.4.3
@@ -18,7 +18,7 @@ django-crispy-forms==1.9.0
 django-environ==0.4.5
 django-ses==1.0.2
 django-storages==1.9.1
-django-tenant-schemas==1.9.0
+django-tenant-schemas==1.11.0
 django-user-agents==0.4.0
 docker==4.2.0
 docker-compose==1.25.5
@@ -30,10 +30,12 @@ idna==2.7
 importlib-metadata==1.6.0
 jmespath==0.10.0
 jsonschema==3.2.0
+ordered-set==4.1.0
 paramiko==2.7.1
 pathspec==0.5.9
 Pillow==8.3.2
-psycopg2==2.8.5
+psycopg2==2.9.6
+psycopg2-binary==2.9.6
 pyasn1==0.4.8
 pycparser==2.20
 PyNaCl==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,7 @@ ordered-set==4.1.0
 paramiko==2.7.1
 pathspec==0.5.9
 Pillow==8.3.2
-psycopg2==2.9.6
-psycopg2-binary==2.9.6
+psycopg2-binary<2.9
 pyasn1==0.4.8
 pycparser==2.20
 PyNaCl==1.3.0

--- a/rush/templates/rush/event.html
+++ b/rush/templates/rush/event.html
@@ -6,7 +6,26 @@
     <h1 style="display: inline">{{ event.name }}&nbsp;&nbsp;&nbsp;<span class="badge badge-info">Round {{ event.round }}</span></h1>
     <h3>{{ event.date }}, {{ event.time }}</h3>
     <h3>{{ event.location }}</h3>
-    <br>
+    {% if perms.core.activate_rushsignin %}
+	<div class="border rounded" style="border-color: {{ settings.primary_color_theme }}!important">
+        <div class="rush-index-admin-container">
+            <div class="custom-control custom-switch">
+                <input type="checkbox" class="custom-control-input" id="rush_signin_switch" {% if settings.rush_signin_active %}checked{% endif %} onclick="window.location= '/rush/toggle_rush_signin'">
+                <label class="custom-control-label" for="rush_signin_switch">Rush signin is <strong>{% if settings.rush_signin_active %} active {% else %} inactive{% endif %}</strong></label>
+            </div>
+        </div>
+    </div>
+	{% endif %}
+    {% if settings.rush_signin_active %}
+    <div class="alert alert-success rush-signin-inactive-alert">
+        Rush signin is active.  <a href="/rush/signin{{event.id}}">Click here to sign in for this event.</a>
+    </div>
+    {% else %}
+    <div class="alert alert-danger rush-signin-inactive-alert">
+        Rush signin is not active.  Rush signin must be enabled before rushees will be able to signin to events.
+    </div>
+    {% endif %}
+    
     <h2>Attendance ({{ event.attendance.count }})</h2>
     <table class="table table-hover">
         <thead>

--- a/rush/templates/rush/rushee.html
+++ b/rush/templates/rush/rushee.html
@@ -18,7 +18,7 @@
                     {% endif %}
                 </div>
                 <div class="col" style="text-align: center">
-                    <a href="/rush/current_rushees"><button class="btn btn-secondary" style="width: 110px">Back to list</button></a>
+                    <a href="/rush"><button class="btn btn-secondary" style="width: 110px">Back to list</button></a>
                 </div>
                 <div class="col" style="text-align: right">
                     {% if next_url != "" %}
@@ -38,11 +38,26 @@
         <div class="col-md-4">
             <h1 class="display-4">{{ rushee.name }}</h1>
             <br>
+            <h2 class="display-6">Round: {{ rushee.round }}</h2>
             <br>
             {% if perms.rush.change_rushee %}
-            <a href="/rush/votepage{{ rushee.id }}"><button class="btn btn-primary" style="width: 183">Open Voting</button></a><br><br>
-            <a href="/rush/rushee{{ rushee.id }}/push"><button class="btn btn-success">Send Through</button></a>
-            <a href="/rush/rushee{{ rushee.id }}/cut"><button class="btn btn-danger">Cut</button></a><br><br>
+            <div class="row" style="width: 70%">
+                <div class="col-12">
+                    <a href="/rush/votepage{{ rushee.id }}"><button class="btn btn-primary" style="width: 100%">Open Voting</button></a><br><br>
+                </div>
+            </div>
+            <div class="row" style="width: 70%">
+                <div class="col-8">
+                    <a href="/rush/rushee{{ rushee.id }}/push"><button class="btn btn-success" style="width: 100%">Send to Next Round</button></a>
+                </div>
+                <div class="col-4">
+                    {% if rushee.cut != 0 %}
+                        <a href="/rush/rushee{{ rushee.id }}/uncut"><button class="btn btn-danger" style="width: 100%">Uncut</button></a><br><br>
+                    {% else %}
+                        <a href="/rush/rushee{{ rushee.id }}/cut"><button class="btn btn-danger" style="width: 100%">Cut</button></a><br><br>
+                    {% endif %}
+                </div>
+            </div>
             {% endif %}
         </div>
         <div class="col-md-4">

--- a/rush/templates/rush/signin.html
+++ b/rush/templates/rush/signin.html
@@ -3,13 +3,13 @@
 {% load static %}
 {% if perms.core.activate_rushsignin %}
 <div class="container">
-    <br><br>
+    <br>
     <div class="custom-control custom-switch">
         <input type="checkbox" class="custom-control-input" id="rush_signin_switch" {% if settings.rush_signin_active %}checked{% endif %} onclick="window.location = '/rush/toggle_rush_signin'">
         <label class="custom-control-label" for="rush_signin_switch">Rush signin is <b>{% if settings.rush_signin_active %} active {% else %} inactive{% endif %}</b></label>
+    <br><br>
     </div>
 </div>
-<br>
 {% endif %}
 {% if not settings.rush_signin_active %}
 <br>
@@ -88,21 +88,9 @@
     </div>
     {% endif %}
 {% else %}
-<br>
-<div class="dropdown" style="margin-left: 5%">
-    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Change event
-    </button>
-    <div class="dropdown-menu" aria-labelledby="dropdownMenu">
-        {% for dropdown_event in events %}
-            <a class="dropdown-item" href="signin{{ dropdown_event.id }}">{{ dropdown_event.name }}</a>
-        {% endfor %}
-    </div>
-</div>
-<br>
 
-
-<h1 style="margin-left: 5%">{{ event.name }}&nbsp;&nbsp;&nbsp;<span class="badge badge-info">Round {{ event.round }}</span></h1>
+<h1 style="margin-left: 5%">Event Signin</h1>
+<h2 style="margin-left: 5%">{{ event.name }}&nbsp;&nbsp;&nbsp;<span class="badge badge-info">Round {{ event.round }}</span></h2>
 {% if event.new_rushees_allowed %}
 <form style="margin-left: 10%; margin-right:10%" method="post" action="register{{ event.id }}">
     {% csrf_token %}
@@ -232,7 +220,6 @@
     <div class="alert alert-success" role="alert">
         Click on your name to sign in.
     </div>
-    <h2>Current Rushees</h2>
     <input type="text" class="form-control rounded" onkeyup="filter_list()" id="rush_signin_search" placeholder="&#xF002; Search" style="font-family:Arial, FontAwesome" ></input><br>
     <table class="table table-hover" id="list_table">
         <thead>

--- a/rush/tests.py
+++ b/rush/tests.py
@@ -309,13 +309,6 @@ class SigninTestCase(TenantTestCase):
         self.assertContains(response, 'Click on your name to sign in.')
         self.assertNotContains(response, 'action="register')
 
-    def test_rush_event_dropdown(self):
-        """ tests that rush events appear as choices in the dropdown selector """
-        path = reverse('rush:signin')
-        response = self.client.post(path)
-        self.assertContains(response, '<a class="dropdown-item" href="signin' + str(self.event1.pk) + '">')
-        self.assertContains(response, '<a class="dropdown-item" href="signin' + str(self.event2.pk) + '">')
-
     def test_click_to_signin_link(self):
         """ tests that rushees can click to signin to events """
         path = reverse('rush:signin', kwargs=dict(event_id=self.event2.pk))

--- a/rush/tests.py
+++ b/rush/tests.py
@@ -537,6 +537,16 @@ class VotingTestCase(TenantTestCase):
         response = self.client.post(path, follow=True)
         self.assertContains(response, '<h1 class="display-4">test_rushee_2</h1>')
 
+    def test_uncut_rushee(self):
+        """ tests uncutting rushee """
+        path = reverse('rush:cut', kwargs=dict(rushee_id=self.rushee.pk))
+        self.client.post(path, follow=True)
+        self.rushee.refresh_from_db()
+        uncut_path = reverse('rush:uncut', kwargs=dict(rushee_id=self.rushee.pk))
+        self.client.post(uncut_path, follow=True)
+        self.rushee.refresh_from_db()
+        self.assertFalse(self.rushee.cut)
+
     def test_votepage(self):
         self.rushee.voting_open = False
         self.rushee.save()

--- a/rush/urls.py
+++ b/rush/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('register<int:event_id>', views.register, name='register'),
     path('rushee<int:rushee_id>/push', views.push_rushee, name="push"),
     path('rushee<int:rushee_id>/cut', views.cut_rushee, name="cut"),
+    path('rushee<int:rushee_id>/uncut', views.uncut_rushee, name="uncut"),
     path('votepage<int:rushee_id>', views.votepage, name="votepage"),
     path('results<int:rushee_id>', views.results, name="results"),
     path('vote<int:rushee_id>/<str:value>', views.vote, name="vote"),

--- a/rush/views.py
+++ b/rush/views.py
@@ -58,7 +58,7 @@ def index(request):
     round_range = range(1, settings.num_rush_rounds + 1)
     round_groups = []
     for i in round_range:
-        round_group = all_events.filter(round=i)
+        round_group = all_events.filter(round=i).order_by('date').reverse()
         round_groups.append(round_group)
 
     context = {
@@ -511,7 +511,7 @@ def push_rushee(request, rushee_id):
 
 @permission_required('rush.change_rushee')
 def cut_rushee(request, rushee_id):
-    """ cut a rushee, setting cut equal to the round they were cut in
+    """ cut a rushee, setting cut equal to the True
         rushee_id -- primary key of rushee being cut
     """
     this_rushee = Rushee.objects.get(id=rushee_id)
@@ -532,6 +532,16 @@ def cut_rushee(request, rushee_id):
         next_url = '/rush/current_rushees'
 
     return HttpResponseRedirect(next_url)
+
+@permission_required('rush.change_rushee')
+def uncut_rushee(request, rushee_id):
+    """ uncut a rushee, setting cut equal to False
+        rushee_id -- primary key of rushee being uncut
+    """
+    this_rushee = Rushee.objects.get(id=rushee_id)
+    this_rushee.cut = False
+    this_rushee.save()
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
 @permission_required('rush.change_rushee')
 def votepage(request, rushee_id):

--- a/rush/views.py
+++ b/rush/views.py
@@ -11,7 +11,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib import messages
 from django.http import Http404
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, require_POST
 from core.views import getSettings
 from core.models import SiteSettings
 from .forms import CommentForm, RusheeForm, FilterForm
@@ -534,6 +534,7 @@ def cut_rushee(request, rushee_id):
     return HttpResponseRedirect(next_url)
 
 @permission_required('rush.change_rushee')
+@require_POST
 def uncut_rushee(request, rushee_id):
     """ uncut a rushee, setting cut equal to False
         rushee_id -- primary key of rushee being uncut

--- a/scripts/start-up.sh
+++ b/scripts/start-up.sh
@@ -53,7 +53,10 @@ python manage.py collectstatic --noinput
 
 # load fixtures
 echo "from organizations.models import Client; Client.objects.create(domain_url='test.localhost', schema_name='test', name='Test Tenant'); Client.objects.create(domain_url='localhost', schema_name='public', name='public'); exit();" | python manage.py shell
-python manage.py tenant_command loaddata --schema=test auth.json
-python manage.py tenant_command loaddata --schema=test settings.json 
+
+# python manage.py tenant_command loaddata --schema=test auth.json
+echo "from django.core.management import call_command; call_command('loaddata', 'auth.json');" | python manage.py tenant_command --schema=test shell
+# python manage.py tenant_command loaddata --schema=test settings.json 
+echo "from django.core.management import call_command; call_command('loaddata', 'settings.json');" | python manage.py tenant_command --schema=test shell
 
 echo "Done!"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey=csyager_greeklink-core
 sonar.organization=csyager
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.9
 sonar.coverage.exclusions=env/**, **/tests.py, **/static/**, **/template/**, **/migrations/**, **/__pycache__/**, **/admin.py


### PR DESCRIPTION
* Fix issue where there was no clear path to rush signin.  Messaging is now clearer:  Recruitment -> select an event -> if rush signin is active, link to signin page is present on top of screen.
* Update dependency versions
* Add uncut rushee function, only available for admins.  This is to make it easier to manipulate rushees outside of the admin module.
* Add round indicator to rushee page.  Changed copy text on buttons to make it more clear that "sending through" a rushee means promoting them to the next round.
* Recruitment events are now ordered on the index page by the date that they occur.  This seems clearer to me.
