### PR TITLE
add input validation on organization select

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -45,12 +45,19 @@ class CustomSelect(Select):
         return option
 
 class OrganizationSelectForm(forms.Form):
+    
     def __init__(self, *args, **kwargs):
         super(OrganizationSelectForm, self).__init__(*args, **kwargs)
         self.ORG_CHOICES = [('', 'Click to select organization')]
         for org in Client.objects.all().exclude(name='public').exclude(name='health'):
-            self.ORG_CHOICES.append((org.domain_url, org.name))
+                self.ORG_CHOICES.append((org.domain_url, org.name))
         self.fields['organization'].choices = self.ORG_CHOICES
+    
+    def is_valid(self):
+        if self.data['organization'] not in [i[0] for i in self.ORG_CHOICES]:
+            print(f'{self.data["organization"]} not in {[i[0] for i in self.ORG_CHOICES]}')
+            return False
+        return super(OrganizationSelectForm, self).is_valid()
 
     organization = forms.ChoiceField(label="Select your organization",
         widget=CustomSelect(attrs={'placeholder': 'Select your organization', 'class': 'form-control rounded'}))

--- a/core/views.py
+++ b/core/views.py
@@ -83,11 +83,18 @@ class CustomLoginView(LoginView):
             return super(CustomLoginView, self).post(request, *args, **kwargs)
         else:
             try:
+                protocol = request.build_absolute_uri('/').split(':')[0]
                 port = ':' + request.build_absolute_uri('/').split(':')[2]
             except IndexError:
+                protocol = 'https'
                 port = ''
-            redirect_tenant_url = request.POST.get('organization')
-            return HttpResponseRedirect("http://" + redirect_tenant_url + port)
+            form = OrganizationSelectForm(request.POST)
+            if form.is_valid():
+                redirect_tenant_url = form.cleaned_data['organization']
+                return HttpResponseRedirect(protocol + "://" + redirect_tenant_url + port)
+            else:
+                print(form.errors)
+                return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
 # index page
 @login_required

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -42,7 +42,19 @@ else:
     DEBUG = False
 
 # for health checks:  Application Load Balancer DNS needs to be allowed here
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.localhost', '.elasticbeanstalk.com', 'greeklink-prod-env.us-east-1.elasticbeanstalk.com', '.greeklink-prod-env.us-east-1.elasticbeanstalk.com', 'greek-rho.com', '.greek-rho.com', '172.31.88.161', 'awseb-awseb-1xs69vwf6dk11-1836811465.us-east-1.elb.amazonaws.com', 'awseb-AWSEB-18Y3IQZOB8OVQ-1983300930.us-east-1.elb.amazonaws.com']
+ALLOWED_HOSTS = [
+    'localhost', 
+    '127.0.0.1', 
+    '.localhost', 
+    '.elasticbeanstalk.com', 
+    'greeklink-prod-env.us-east-1.elasticbeanstalk.com', 
+    '.greeklink-prod-env.us-east-1.elasticbeanstalk.com', 
+    'greek-rho.com', 
+    '.greek-rho.com', 
+    '172.31.88.161', 
+    'awseb-awseb-1xs69vwf6dk11-1836811465.us-east-1.elb.amazonaws.com', 
+    'awseb-AWSEB-18Y3IQZOB8OVQ-1983300930.us-east-1.elb.amazonaws.com'
+]
 
 # gets health check IP address on elastic beanstalk and allows it
 if ENV == 'production':

--- a/greeklink_core/settings.py
+++ b/greeklink_core/settings.py
@@ -51,7 +51,6 @@ ALLOWED_HOSTS = [
     '.greeklink-prod-env.us-east-1.elasticbeanstalk.com', 
     'greek-rho.com', 
     '.greek-rho.com', 
-    '172.31.88.161', 
     'awseb-awseb-1xs69vwf6dk11-1836811465.us-east-1.elb.amazonaws.com', 
     'awseb-AWSEB-18Y3IQZOB8OVQ-1983300930.us-east-1.elb.amazonaws.com'
 ]

--- a/organizations/tests.py
+++ b/organizations/tests.py
@@ -1,3 +1,47 @@
-from django.test import TestCase
+from django.test import TestCase, Client as HttpClient
+from .models import Client
+from django.urls import reverse
+from core import urls
+from core.forms import OrganizationSelectForm
+from tenant_schemas.test.cases import TenantTestCase
+from tenant_schemas.test.client import TenantClient
+
 
 # Create your tests here.
+class CommunityLoginTestCase(TestCase):
+
+    def setUp(self):
+        self.http_client = HttpClient()
+        self.public_client = Client.objects.create(name="public", schema_name="public", domain_url="localhost")
+        self.test_client = Client.objects.create(name="test", schema_name="test", domain_url="test.localhost")
+
+    # tests community selection page
+    def test_community_login_dropdown(self):
+        path = reverse('login')
+        response = self.http_client.get(path, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'<option value="{self.test_client.domain_url}">')
+        self.assertNotContains(response, f'<option value="some.url.not.present">')
+
+    def test_community_login_valid_input(self):
+        path = reverse('login')
+        post_data = {
+            'organization': self.test_client.domain_url
+        }
+        form = OrganizationSelectForm(post_data)
+        self.assertTrue(form.is_valid())
+        response = self.http_client.post(path, post_data, follow=True)
+        self.assertEqual(response.status_code, 200)
+    
+    def test_community_login_invalid_input(self):
+        path = reverse('login')
+        post_data = {
+            'organization': "some.url.not.present"
+        }
+        form = OrganizationSelectForm(post_data)
+        self.assertFalse(form.is_valid())
+        response = self.http_client.post(path, post_data, follow=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue("some.url.not.present is not one of the available choices" in str(form.errors))
+        response = self.http_client.post(path, post_data, follow=True, HTTP_REFERER=path)
+        self.assertContains(response, "Select your organization")


### PR DESCRIPTION
* addresses security concern caught by sonarqube
  - by injecting request data, users could redirect to any domain from the public-schema organization selection page
  - a bad actor could craft a request including redirect data to a malicious URL, then trick users into submitting it.  
  - this change prevents this from occuring by rejecting form submissions that aren't proper organization domain urls.

* adds unit testing
